### PR TITLE
Change extrinsic hasher to use blake two 256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -164,7 +164,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -770,16 +770,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq 0.4.2",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -895,7 +895,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1108,6 +1108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,7 +1211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -2772,7 +2781,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3493,7 +3502,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3505,7 +3514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4825,7 +4834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4837,7 +4846,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -4849,7 +4858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 

--- a/src/chain/client.rs
+++ b/src/chain/client.rs
@@ -6,7 +6,6 @@
 use crate::{error::QuantusError, log_verbose};
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use qp_dilithium_crypto::types::DilithiumSignatureScheme;
-use qp_poseidon::PoseidonHasher;
 use sp_core::{crypto::AccountId32, ByteArray};
 use sp_runtime::{traits::IdentifyAccount, MultiAddress};
 use std::{sync::Arc, time::Duration};
@@ -18,17 +17,17 @@ use subxt::{
 use subxt_metadata::Metadata as SubxtMetadata;
 
 #[derive(Debug, Clone, Copy)]
-pub struct SubxtPoseidonHasher;
+pub struct SubxtBlake2bHasher;
 
-impl subxt::config::Hasher for SubxtPoseidonHasher {
+impl subxt::config::Hasher for SubxtBlake2bHasher {
 	type Output = sp_core::H256;
 
 	fn new(_metadata: &SubxtMetadata) -> Self {
-		SubxtPoseidonHasher
+		SubxtBlake2bHasher
 	}
 
 	fn hash(&self, bytes: &[u8]) -> Self::Output {
-		<PoseidonHasher as sp_runtime::traits::Hash>::hash(bytes)
+		<sp_runtime::traits::BlakeTwo256 as sp_runtime::traits::Hash>::hash(bytes)
 	}
 }
 
@@ -38,8 +37,8 @@ impl Config for ChainConfig {
 	type AccountId = AccountId32;
 	type Address = MultiAddress<Self::AccountId, ()>;
 	type Signature = DilithiumSignatureScheme;
-	type Hasher = SubxtPoseidonHasher;
-	type Header = SubstrateHeader<u32, SubxtPoseidonHasher>;
+	type Hasher = SubxtBlake2bHasher;
+	type Header = SubstrateHeader<u32, SubxtBlake2bHasher>;
 	type AssetId = u32;
 	type ExtrinsicParams = DefaultExtrinsicParams<Self>;
 }

--- a/src/cli/block.rs
+++ b/src/cli/block.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use clap::Subcommand;
 use colored::Colorize;
-use qp_poseidon::PoseidonHasher;
 use sp_core::crypto::Ss58Codec;
+use sp_runtime::traits::Hash;
 use std::str::FromStr;
 use subxt::events::EventDetails;
 
@@ -706,8 +706,8 @@ fn summarize_extrinsic(ext_hex: &str) -> (usize, String, String) {
 		(ext_str.as_bytes().to_vec(), ext_str.len())
 	};
 
-	// Compute extrinsic hash using Poseidon (chain hasher)
-	let h = <PoseidonHasher as sp_runtime::traits::Hash>::hash(&bytes);
+	// Compute extrinsic hash using Blake2b (chain hasher)
+	let h = sp_runtime::traits::BlakeTwo256::hash(&bytes);
 	let hash_hex = format!("{h:#x}");
 
 	let preview = if ext_str.len() > 20 { ext_str[..20].to_string() } else { ext_str.to_string() };


### PR DESCRIPTION
## Summary
Since now chain doesn't use poseidon to hash the extrinsic, CLI will also need to not use it so we return correct hash.