### PR TITLE
split block ranges when there's too many proofs returned

### DIFF
--- a/src/collect_rewards_lib.rs
+++ b/src/collect_rewards_lib.rs
@@ -303,9 +303,9 @@ pub async fn collect_rewards<P: ProgressCallback>(
 	let address_hash = compute_address_hash(&wormhole_address_bytes);
 	let prefix = get_hash_prefix(&address_hash, 8);
 
-	let params = TransferQueryParams::new().with_limit(1000);
+	let params = TransferQueryParams::new();
 	let transfers = subsquid_client
-		.query_transfers_by_prefix(Some(vec![prefix]), None, params)
+		.query_all_transfers_by_prefix(Some(vec![prefix]), None, params)
 		.await?;
 
 	// Filter to only transfers TO our wormhole address
@@ -599,9 +599,9 @@ pub async fn query_pending_transfers(
 	let address_hash = compute_address_hash(&wormhole_secret.address);
 	let prefix = get_hash_prefix(&address_hash, 8); // 8 hex chars for good privacy
 
-	let params = TransferQueryParams::new().with_limit(1000);
+	let params = TransferQueryParams::new();
 	let transfers = subsquid_client
-		.query_transfers_by_prefix(Some(vec![prefix]), None, params)
+		.query_all_transfers_by_prefix(Some(vec![prefix]), None, params)
 		.await?;
 
 	// Filter to only transfers TO our wormhole address
@@ -652,9 +652,9 @@ pub async fn query_pending_transfers_for_address(
 	let address_hash = compute_address_hash(wormhole_address_bytes);
 	let prefix = get_hash_prefix(&address_hash, 8);
 
-	let params = TransferQueryParams::new().with_limit(1000);
+	let params = TransferQueryParams::new();
 	let transfers = subsquid_client
-		.query_transfers_by_prefix(Some(vec![prefix]), None, params)
+		.query_all_transfers_by_prefix(Some(vec![prefix]), None, params)
 		.await?;
 
 	// Filter to only transfers TO our wormhole address

--- a/src/subsquid/client.rs
+++ b/src/subsquid/client.rs
@@ -166,6 +166,67 @@ impl SubsquidClient {
 		Ok(data.transfers_by_hash_prefix.transfers)
 	}
 
+	/// Fetch every transfer matching the given prefixes, paginating by block range.
+	///
+	/// The server caps any single query at 1000 results and rejects larger result sets
+	/// with a "Query returned N results, which exceeds the limit of 1000" error. This
+	/// method handles that by binary-splitting the `[after_block, before_block]` range
+	/// whenever the cap is hit, then concatenating results.
+	///
+	/// `base_params.after_block` / `base_params.before_block` are honored as the initial
+	/// bounds; unset means `0` / `i32::MAX` (GraphQL `Int` is signed 32-bit so we can't
+	/// exceed that). Other filters (amount, offset) are forwarded unchanged. `limit` is
+	/// always set to the server max (1000) per sub-query.
+	pub async fn query_all_transfers_by_prefix(
+		&self,
+		to_prefixes: Option<Vec<String>>,
+		from_prefixes: Option<Vec<String>>,
+		base_params: TransferQueryParams,
+	) -> Result<Vec<Transfer>> {
+		const SERVER_MAX_LIMIT: u32 = 1000;
+		const LIMIT_EXCEEDED_MARKER: &str = "exceeds the limit";
+		const MAX_BLOCK_SENTINEL: u32 = i32::MAX as u32;
+
+		let initial_lo = base_params.after_block.unwrap_or(0);
+		let initial_hi = base_params.before_block.unwrap_or(MAX_BLOCK_SENTINEL);
+
+		if initial_lo > initial_hi {
+			return Ok(vec![]);
+		}
+
+		let mut all: Vec<Transfer> = Vec::new();
+		let mut stack: Vec<(u32, u32)> = vec![(initial_lo, initial_hi)];
+
+		while let Some((lo, hi)) = stack.pop() {
+			let params = base_params
+				.clone()
+				.with_after_block(lo)
+				.with_before_block(hi)
+				.with_limit(SERVER_MAX_LIMIT);
+
+			match self
+				.query_transfers_by_prefix(to_prefixes.clone(), from_prefixes.clone(), params)
+				.await
+			{
+				Ok(transfers) => all.extend(transfers),
+				Err(e) if e.to_string().contains(LIMIT_EXCEEDED_MARKER) => {
+					if lo == hi {
+						return Err(QuantusError::Generic(format!(
+							"More than {} transfers in single block {}: {}",
+							SERVER_MAX_LIMIT, lo, e
+						)));
+					}
+					let mid = lo + (hi - lo) / 2;
+					stack.push((mid + 1, hi));
+					stack.push((lo, mid));
+				},
+				Err(e) => return Err(e),
+			}
+		}
+
+		Ok(all)
+	}
+
 	/// Query transfers for a set of addresses using privacy-preserving hash prefixes.
 	///
 	/// This is a convenience method that:
@@ -375,5 +436,15 @@ mod tests {
 		assert_eq!(params.offset, 10);
 		assert_eq!(params.after_block, Some(1000));
 		assert_eq!(params.before_block, Some(2000));
+	}
+
+	// Guards the substring the paginator matches on. If the server ever changes this
+	// wording, `query_all_transfers_by_prefix` will stop triggering binary-split and
+	// this test will fail loudly.
+	#[test]
+	fn test_server_limit_error_marker() {
+		let server_message = "Query returned 1234 results, which exceeds the limit of 1000. \
+			Please use longer hash prefixes for more specific queries.";
+		assert!(server_message.contains("exceeds the limit"));
 	}
 }


### PR DESCRIPTION


Fix for this: 

❌ Error: Error: Error: GraphQL errors: Query returned 2103 results, which exceeds the limit of 1000. Please use longer hash prefixes for more specific queries.


Summary of changes:

**[`src/subsquid/client.rs`](src/subsquid/client.rs)** — added `SubsquidClient::query_all_transfers_by_prefix`. It seeds the range from `base_params.after_block`/`before_block` (defaulting to `0` and `u32::MAX`), calls the existing `query_transfers_by_prefix` per sub-range with `limit=1000`, and when the server responds with the "exceeds the limit" error it binary-splits at the midpoint and retries via an explicit `Vec` stack (no async recursion boxing). Any other error propagates immediately. If a single block legitimately has >1000 matches it fails loudly rather than looping.

**[`src/collect_rewards_lib.rs`](src/collect_rewards_lib.rs)** — swapped the three call sites (`collect_rewards`, `query_pending_transfers`, `query_pending_transfers_for_address`) to use the paginating method. Removed the now-irrelevant `with_limit(1000)` parameters. Privacy prefix stays at 8 hex chars; SDK function signatures unchanged.

**Test** — added `test_server_limit_error_marker` guarding the `"exceeds the limit"` substring the paginator pattern-matches on, so future server wording changes break a test instead of silently breaking production.

`cargo build` and all subsquid/collect_rewards unit tests pass.

Regarding your follow-up question on scale: after this fix there's no architectural cap on transfers per `collect_rewards` call. The true per-transaction cap remains 16 proofs (`num_leaf_proofs`); 1000s of transfers are submitted as `ceil(N/16)` unsigned extrinsics back-to-back. The bottleneck becomes serial proof generation time and in-memory buffering of all proof bytes, not the indexer or the chain.