### PR TITLE
ci: Automate version bump to v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-cli"
-version = "1.3.4"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-cli"
 readme = "README.md"
 repository = "https://github.com/Quantus-Network/quantus-cli"
-version = "1.3.4"
+version = "1.4.0"
 
 [lib]
 name = "quantus_cli"


### PR DESCRIPTION
Automated version bump for release v1.4.0.

https://github.com/Quantus-Network/quantus-cli/actions/runs/27390427845

Triggered by workflow run: minor

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no functional code or dependency updates.
> 
> **Overview**
> Automated **minor release** bump for `quantus-cli` from **1.3.4** to **1.4.0**.
> 
> Updates the crate `version` in `Cargo.toml` and the matching `quantus-cli` package entry in `Cargo.lock`. No application or dependency logic changes beyond the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f07bb500bddef4320854952142d7df7f7a29dd73. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->