### PR TITLE
ci: Automate version bump to v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-cli"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-cli"
 readme = "README.md"
 repository = "https://github.com/Quantus-Network/quantus-cli"
-version = "1.4.0"
+version = "1.5.0"
 
 [lib]
 name = "quantus_cli"


### PR DESCRIPTION
Automated version bump for release v1.5.0.

https://github.com/Quantus-Network/quantus-cli/actions/runs/27418145438

Triggered by workflow run: minor

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no functional code or dependency changes in the diff.
> 
> **Overview**
> Bumps the **`quantus-cli`** crate version from **1.4.0** to **1.5.0** in `Cargo.toml` and the matching **`quantus-cli`** entry in `Cargo.lock`, consistent with an automated minor release workflow for **v1.5.0**.
> 
> No application, dependency, or source changes are included in this diff—only release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad796030f868364bba2078cdce4e2d71717ecb50. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->