### PR TITLE
ci: Automate version bump to v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-cli"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-cli"
 readme = "README.md"
 repository = "https://github.com/Quantus-Network/quantus-cli"
-version = "1.5.0"
+version = "1.6.0"
 
 [lib]
 name = "quantus_cli"


### PR DESCRIPTION
Automated version bump for release v1.6.0.

https://github.com/Quantus-Network/quantus-cli/actions/runs/30080077116

Triggered by workflow run: minor

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump; no runtime, security, or behavioral changes.
> 
> **Overview**
> **Release v1.6.0** — automated minor version bump with no application or library code changes.
> 
> Updates the crate `version` in **`Cargo.toml`** and the matching **`quantus-cli`** entry in **`Cargo.lock`** from **1.5.0** to **1.6.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36e6b95c79fc0ac697eecfb5a056bb7b03bed693. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->