### PR TITLE
chore: bump poseidon 3.1.0, plonky2 1.5.5, crystals 4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,122 +3240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "p3-dft"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b2764a3982d22d62aa933c8de6f9d71d8a474c9110b69e675dea1887bdeffc"
-dependencies = [
- "itertools 0.14.0",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
- "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc13a73509fe09c67b339951ca8d4cc6e61c9bf08c130dbc90dda52452918cc2"
-dependencies = [
- "itertools 0.14.0",
- "num-bigint",
- "p3-maybe-rayon",
- "p3-util",
- "paste",
- "rand 0.9.5",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-goldilocks"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552849f6309ffde34af0d31aa9a2d0a549cb0ec138d9792bfbf4a17800742362"
-dependencies = [
- "num-bigint",
- "p3-dft",
- "p3-field",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
- "paste",
- "rand 0.9.5",
- "serde",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e1e9f69c2fe15768b3ceb2915edb88c47398aa22c485d8163deab2a47fe194"
-dependencies = [
- "itertools 0.14.0",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
- "rand 0.9.5",
- "serde",
- "tracing",
- "transpose",
-]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f765046b763d046728b3246b690f81dfa7ccd7523b7a1582c74f616fbce6a0"
-
-[[package]]
-name = "p3-mds"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c90541c6056712daf2ee69ec328db8b5605ae8dbafe60226c8eb75eaac0e1f9"
-dependencies = [
- "p3-dft",
- "p3-field",
- "p3-symmetric",
- "p3-util",
- "rand 0.9.5",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e9f053f120a78ad27e9c1991a0ea547777328ca24025c42364d6ee2667d59a"
-dependencies = [
- "p3-field",
- "p3-mds",
- "p3-symmetric",
- "p3-util",
- "rand 0.9.5",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d5db8f05a26d706dfd8aaf7aa4272ca4f3e7a075db897ec7108f24fad78759"
-dependencies = [
- "itertools 0.14.0",
- "p3-field",
- "serde",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfee67245d9ce78a15176728da2280032f0a84b5819a39a953e7ec03cfd9bd7"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,19 +3701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qp-poseidon-constants"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300d8b01e4a492b202e739ab5f73215b261905911020cc0f74a22109365e3bd7"
-dependencies = [
- "p3-field",
- "p3-goldilocks",
- "p3-poseidon2",
- "rand 0.9.5",
- "rand_chacha 0.9.0",
-]
-
-[[package]]
 name = "qp-poseidon-core"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3866,8 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-aggregator"
-version = "4.1.0"
-source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36c1e817cba09384f092f6f1cda8016cc39637c878c1b80788d8c7d5bd75b40"
 dependencies = [
  "anyhow",
  "hex",
@@ -3884,8 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit"
-version = "4.1.0"
-source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418648e0835bb47c7e6fa908bce246e9e9fce042f857b15e652b2591ff869e76"
 dependencies = [
  "anyhow",
  "hex",
@@ -3897,8 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit-builder"
-version = "4.1.0"
-source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0716238af4fa0c0efdf06f30ccbff90534c0d9e700c3d90aa9d3be79fb10d2fe"
 dependencies = [
  "anyhow",
  "clap",
@@ -3911,16 +3785,18 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-inputs"
-version = "4.1.0"
-source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9385fee220d58083a3c833ff9ee87c2346f77c7e869f35bbe12ecd8dad3d076f"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "qp-wormhole-prover"
-version = "4.1.0"
-source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c90421378b57eeb08f3e60f426aa861b2ad741942dcd795c43b5665171026a"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -3930,8 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-verifier"
-version = "4.1.0"
-source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fce3fa8c1866b7c0d4279e2d004d1b3959eb8d5e67d656c738725b8ac039d9"
 dependencies = [
  "anyhow",
  "qp-plonky2-verifier",
@@ -3941,12 +3818,12 @@ dependencies = [
 
 [[package]]
 name = "qp-zk-circuits-common"
-version = "4.1.0"
-source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78477b533829319a41b946bf8bdc1bc778f9ed1806f156eb584aa3a6ff764b3b"
 dependencies = [
  "anyhow",
  "qp-plonky2",
- "qp-poseidon-constants",
  "qp-poseidon-core",
  "qp-wormhole-inputs",
  "rand 0.8.6",
@@ -5541,12 +5418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6267,16 +6138,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -711,6 +711,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
@@ -3711,8 +3712,7 @@ dependencies = [
 [[package]]
 name = "qp-dilithium-crypto"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c08c0931c083cc461bd09795d528a0e4f34e6e4745e9bb52eadb3aad2e60469"
+source = "git+https://github.com/Quantus-Network/chain?branch=chore%2Fbump-crypto-deps-2026-08#b8d0bb077ed0487424b66df869d8b7de436e1c11"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -3723,13 +3723,14 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
 name = "qp-plonky2"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff530eb14bc9389c7c5dad8fc3b1a90a6a5784f34daf74a34b963a562b73b0d0"
+checksum = "8fd331d489a309f88e2d0e35a2b996932c7d92038b91ccc656a0a8e6b11b6977"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3755,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-core"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da3052436ca37dbb0540280e37846da1e826bd026745798853b6ffbb3b5e798"
+checksum = "b81a3a9fce99f7bd45b8578f8d9b6a33507d34c2eb2c47c969b464db1ad601d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3776,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-field"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518a71f954222caa0d87fd331254a1651b5ee09d8e21881899478b0a1c2cc42e"
+checksum = "1630d418ddce9feba18d3364596711d07074851757301350de313eef0a31af4f"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -3793,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-verifier"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d3c30ed97690849cf92eb0fdd1d4e6765ecc9e6be6b0a0e9b4dc4accb5145f"
+checksum = "944da5dec21ee476d561f6c38caddf45e829f3cc5fccbc76f6ece03660378dbe"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3830,30 +3831,29 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e32db7b3a5d70086f82f198ecfc021f17cb7ec70a416512dba3488f4a116c1"
+checksum = "5872607e25ea4ee5fb37e64bf1462168e1a36a4e719cdc8a105533c708253918"
 
 [[package]]
 name = "qp-rusty-crystals-dilithium"
-version = "3.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f6eb664c03395b3892f7f18d4f08bff0e256a967bb0146598a0f771d5e99ba"
+checksum = "2facf5349ce149731e6d21dc338f847c78e4a3a65e92e086e2cee244e7cf0457"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "qp-rusty-crystals-hdwallet"
-version = "3.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9a9d975e8bfa2b6726f9668f32bd134a2556ccf65f4d336fed941658e4db67"
+checksum = "40119eb0c9a085722330c15ce17b71ca3aaecf5fa5a44891a47c1c9ec2c3109c"
 dependencies = [
  "bip39",
  "getrandom 0.2.17",
  "hex",
  "hex-literal",
- "hmac 0.12.1",
  "qp-poseidon-core",
  "qp-rusty-crystals-dilithium",
  "serde",
@@ -3866,9 +3866,8 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-aggregator"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c3fb3ef7ce2fe519cab6f10e206bbbace8e3c7739318e1cfbe1eb16779a51d"
+version = "4.1.0"
+source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
 dependencies = [
  "anyhow",
  "hex",
@@ -3885,22 +3884,21 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da895295e488eae1d5fbf63a94ccf388e580595b5607ef51b3e057ac0bef0539"
+version = "4.1.0"
+source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
 dependencies = [
  "anyhow",
  "hex",
  "qp-plonky2",
  "qp-wormhole-inputs",
  "qp-zk-circuits-common",
+ "zeroize",
 ]
 
 [[package]]
 name = "qp-wormhole-circuit-builder"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65d2f36b1f6903679180d0a2cfb5a4147960229b8b74034779f0a9f4644930d"
+version = "4.1.0"
+source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
 dependencies = [
  "anyhow",
  "clap",
@@ -3908,22 +3906,21 @@ dependencies = [
  "qp-wormhole-aggregator",
  "qp-wormhole-circuit",
  "qp-zk-circuits-common",
+ "rand 0.8.6",
 ]
 
 [[package]]
 name = "qp-wormhole-inputs"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b7675995701fc2c229846055fcfdb860ea1118c46437357f3cf6f7c15b73aa"
+version = "4.1.0"
+source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "qp-wormhole-prover"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f105bc62dbab0b4573ef43d4a7c87e6482ea2b7c8b99f18a1b3240c22956fb7f"
+version = "4.1.0"
+source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -3933,9 +3930,8 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-verifier"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474cfd8ae4cd3f76d23867378723f642844368f9d6e0812b3b1df66aa247e24c"
+version = "4.1.0"
+source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
 dependencies = [
  "anyhow",
  "qp-plonky2-verifier",
@@ -3945,9 +3941,8 @@ dependencies = [
 
 [[package]]
 name = "qp-zk-circuits-common"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac5d2eb980e702b7db1458601fbb7a2d5fc86c6713c5c324ecc0e28061fa955"
+version = "4.1.0"
+source = "git+https://github.com/Quantus-Network/qp-zk-circuits?branch=chore%2Fbump-crypto-deps-2026-08#14d81950e4c091fc9a27781b4c3414150a619a93"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -3956,6 +3951,7 @@ dependencies = [
  "qp-wormhole-inputs",
  "rand 0.8.6",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,13 +95,13 @@ anyhow = "1.0"
 
 qp-plonky2 = { version = "1.5.5", default-features = false, features = ["rand", "std"] }
 qp-plonky2-verifier = { version = "1.5.5", default-features = false }
-qp-wormhole-aggregator = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["rayon", "std"] }
-qp-wormhole-circuit = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
-qp-wormhole-circuit-builder = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08" }
-qp-wormhole-inputs = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
-qp-wormhole-prover = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
-qp-wormhole-verifier = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
-qp-zk-circuits-common = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
+qp-wormhole-aggregator = { version = "4.2.0", default-features = false, features = ["rayon", "std"] }
+qp-wormhole-circuit = { version = "4.2.0", default-features = false, features = ["std"] }
+qp-wormhole-circuit-builder = { version = "4.2.0" }
+qp-wormhole-inputs = { version = "4.2.0", default-features = false, features = ["std"] }
+qp-wormhole-prover = { version = "4.2.0", default-features = false, features = ["std"] }
+qp-wormhole-verifier = { version = "4.2.0", default-features = false, features = ["std"] }
+qp-zk-circuits-common = { version = "4.2.0", default-features = false, features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -109,7 +109,7 @@ libc = "0.2"
 [build-dependencies]
 hex = "0.4"
 qp-poseidon-core = "3.1.0"
-qp-wormhole-circuit-builder = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08" }
+qp-wormhole-circuit-builder = { version = "4.2.0" }
 sha2 = "0.10"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,9 @@ argon2 = "0.5"   # Password-based key derivation (quantum-safe)
 rand = "0.9"
 
 # Quantus crypto dependencies (aligned with chain)
-qp-dilithium-crypto = { version = "0.5.0", features = ["serde"] }
-qp-rusty-crystals-dilithium = { version = "3.0.1" }
-qp-rusty-crystals-hdwallet = { version = "3.0.1" }
+qp-dilithium-crypto = { git = "https://github.com/Quantus-Network/chain", branch = "chore/bump-crypto-deps-2026-08", package = "qp-dilithium-crypto", features = ["serde"] }
+qp-rusty-crystals-dilithium = { version = "4.1.0" }
+qp-rusty-crystals-hdwallet = { version = "4.1.0" }
 
 # HTTP client for Subsquid queries
 blake3 = "1.8"
@@ -93,27 +93,27 @@ subxt-metadata = "0.44"
 # ZK proof generation (aligned with chain)
 anyhow = "1.0"
 
-qp-plonky2 = { version = "1.5.4", default-features = false, features = ["rand", "std"] }
-qp-plonky2-verifier = { version = "1.5.4", default-features = false }
-qp-wormhole-aggregator = { version = "3.1.0", default-features = false, features = ["rayon", "std"] }
-qp-wormhole-circuit = { version = "3.1.0", default-features = false, features = ["std"] }
-qp-wormhole-circuit-builder = { version = "3.1.0" }
-qp-wormhole-inputs = { version = "3.1.0", default-features = false, features = ["std"] }
-qp-wormhole-prover = { version = "3.1.0", default-features = false, features = ["std"] }
-qp-wormhole-verifier = { version = "3.1.0", default-features = false, features = ["std"] }
-qp-zk-circuits-common = { version = "3.1.0", default-features = false, features = ["std"] }
+qp-plonky2 = { version = "1.5.5", default-features = false, features = ["rand", "std"] }
+qp-plonky2-verifier = { version = "1.5.5", default-features = false }
+qp-wormhole-aggregator = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["rayon", "std"] }
+qp-wormhole-circuit = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
+qp-wormhole-circuit-builder = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08" }
+qp-wormhole-inputs = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
+qp-wormhole-prover = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
+qp-wormhole-verifier = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
+qp-zk-circuits-common = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08", default-features = false, features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [build-dependencies]
 hex = "0.4"
-qp-poseidon-core = "3.0.2"
-qp-wormhole-circuit-builder = { version = "3.1.0" }
+qp-poseidon-core = "3.1.0"
+qp-wormhole-circuit-builder = { git = "https://github.com/Quantus-Network/qp-zk-circuits", branch = "chore/bump-crypto-deps-2026-08" }
 sha2 = "0.10"
 
 [dev-dependencies]
-qp-poseidon-core = "3.0.2"
+qp-poseidon-core = "3.1.0"
 serial_test = "3.1"
 tempfile = "3.8.1"
 


### PR DESCRIPTION
Crypto bumps to published crates.io versions:

| Crate | To |
|-------|-----|
| qp-poseidon-core | **3.1.0** |
| qp-plonky2 / verifier | **1.5.5** |
| qp-rusty-crystals-* | **4.1.0** |
| qp-wormhole-* / qp-zk-circuits-common | **4.2.0** |

**Temporary:** `qp-dilithium-crypto` still from chain PR branch (`chore/bump-crypto-deps-2026-08`) because crates.io 0.5.0 pins crystals ^3.0.1. Switch to crates.io after chain is merged and dilithium-crypto is republished with crystals 4.1.0.

Lockfile: single version of each of the new crates (wormhole from crates.io, not git).