### PR TITLE
Accept runtime spec 143 / transaction version 3.

### DIFF
--- a/src/bins.rs
+++ b/src/bins.rs
@@ -10,15 +10,15 @@
 //! storage location and regenerates the binaries there on demand.
 //!
 //! Resolution order:
-//! 1. `QUANTUS_BINS_DIR` env var (explicit override; also how local dev opts in to
-//!    `./generated-bins`).
-//! 2. `~/.quantus/generated-bins/` (default for installed binaries).
+//! 1. `QUANTUS_BINS_DIR` env var (optional override, including `./generated-bins`).
+//! 2. `~/.quantus/generated-bins/` (default; generated on demand).
 //!
-//! `./generated-bins/` in the current working directory is detected but never
-//! trusted implicitly: the manifest is unsigned and lives in the directory it
-//! authenticates, so an attacker-prepared checkout could ship a
-//! self-consistent artifact set that passes verification. Resolution fails
-//! with an explicit opt-in instruction instead.
+//! `./generated-bins/` in the current working directory is never used unless
+//! pointed at explicitly via `QUANTUS_BINS_DIR`. The manifest is unsigned and
+//! lives in the directory it authenticates, so an attacker-prepared checkout
+//! could ship a self-consistent artifact set that passes verification. When
+//! CWD artifacts are present without an override they are ignored — resolution
+//! falls through to the per-user store instead of requiring an env var.
 
 use crate::{
 	error::{QuantusError, Result},
@@ -72,24 +72,15 @@ struct ArtifactManifest {
 /// This never generates anything; see [`ensure_bins_dir`] for the full
 /// resolve-and-generate flow.
 ///
-/// Fails if `./generated-bins` exists in the current working directory without
-/// an explicit `QUANTUS_BINS_DIR` opt-in — see the module docs for why the CWD
-/// source cannot be trusted implicitly.
+/// `cwd_dir` is only used for tests; production ignores CWD artifacts unless
+/// they are selected via [`BINS_DIR_ENV`].
 pub fn resolve_bins_dir() -> Result<PathBuf> {
 	resolve_bins_dir_from(std::env::var(BINS_DIR_ENV).ok(), Path::new("generated-bins"))
 }
 
-fn resolve_bins_dir_from(env_override: Option<String>, cwd_dir: &Path) -> Result<PathBuf> {
+fn resolve_bins_dir_from(env_override: Option<String>, _cwd_dir: &Path) -> Result<PathBuf> {
 	if let Some(dir) = env_override {
 		return Ok(PathBuf::from(dir));
-	}
-
-	if cwd_dir.join("config.json").exists() {
-		return Err(QuantusError::Generic(format!(
-			"Found circuit artifacts in ./{dir} but refusing to trust the current working directory implicitly. Set {env}=./{dir} to use them, or run from another directory to use the per-user artifact store",
-			dir = cwd_dir.display(),
-			env = BINS_DIR_ENV,
-		)));
 	}
 
 	Ok(user_bins_dir())
@@ -502,17 +493,18 @@ mod tests {
 	}
 
 	#[test]
-	fn cwd_artifacts_are_refused_without_explicit_opt_in() {
+	fn cwd_artifacts_are_ignored_without_explicit_opt_in() {
 		// #160697 follow-up: an attacker-prepared checkout can ship a
 		// self-consistent ./generated-bins; it must never be trusted implicitly.
+		// Prefer the per-user store over requiring QUANTUS_BINS_DIR.
 		let tmp = TempDir::new().unwrap();
 		let cwd_dir = tmp.path().join("generated-bins");
 		fs::create_dir_all(&cwd_dir).unwrap();
 		fs::write(cwd_dir.join("config.json"), b"{}").unwrap();
 
-		let err = resolve_bins_dir_from(None, &cwd_dir)
-			.expect_err("CWD artifacts must require explicit opt-in");
-		assert!(err.to_string().contains(BINS_DIR_ENV), "unexpected error: {err}");
+		let resolved = resolve_bins_dir_from(None, &cwd_dir)
+			.expect("CWD artifacts must be ignored, not fatal");
+		assert_eq!(resolved, user_bins_dir());
 	}
 
 	#[test]

--- a/src/bins_consts.rs
+++ b/src/bins_consts.rs
@@ -40,5 +40,8 @@ pub const DEFAULT_NUM_LEAF_PROOFS: usize = 7;
 /// Number of private-batch proofs aggregated into a single public batch.
 ///
 /// Must match the chain's pallet-wormhole build default (QP_NUM_PRIVATE_BATCH_PROOFS)
-/// or on-chain verification of public batches will fail.
-pub const DEFAULT_NUM_PRIVATE_BATCH_PROOFS: usize = 4;
+/// or on-chain verification of public batches will fail. The chain moved to 53
+/// (larger batches amortize aggregator proving cost at the 4-bps volume fee);
+/// nodes reject public batches generated with the previous sizing of 4 as
+/// InvalidTransaction.
+pub const DEFAULT_NUM_PRIVATE_BATCH_PROOFS: usize = 53;

--- a/src/cli/exercise/mod.rs
+++ b/src/cli/exercise/mod.rs
@@ -54,6 +54,7 @@ pub struct ExerciseArgs {
 pub enum Phase {
 	Reads,
 	Balances,
+	Utility,
 	Reversible,
 	Multisig,
 	Recovery,
@@ -71,6 +72,7 @@ impl Phase {
 		vec![
 			Phase::Reads,
 			Phase::Balances,
+			Phase::Utility,
 			Phase::Reversible,
 			Phase::Multisig,
 			Phase::Recovery,
@@ -87,6 +89,7 @@ impl Phase {
 		match self {
 			Phase::Reads => "reads",
 			Phase::Balances => "balances",
+			Phase::Utility => "utility",
 			Phase::Reversible => "reversible",
 			Phase::Multisig => "multisig",
 			Phase::Recovery => "recovery",
@@ -194,6 +197,7 @@ async fn run_phases(
 		match phase {
 			Phase::Reads => scenarios::reads::run(ctx, report, &label).await?,
 			Phase::Balances => scenarios::balances::run(ctx, report, &label).await?,
+			Phase::Utility => scenarios::utility::run(ctx, report, &label).await?,
 			Phase::Reversible => scenarios::reversible::run(ctx, report, &label).await?,
 			Phase::Multisig => scenarios::multisig::run(ctx, report, &label).await?,
 			Phase::Recovery => scenarios::recovery::run(ctx, report, &label).await?,

--- a/src/cli/exercise/scenarios/balances.rs
+++ b/src/cli/exercise/scenarios/balances.rs
@@ -4,12 +4,13 @@ use crate::{
 	chain::quantus_subxt,
 	cli::exercise::{
 		report::Report,
-		runner::{submit_ok, ExerciseCtx},
+		runner::{account_id_of, submit_ok, ExerciseCtx},
 	},
 	error::{QuantusError, Result},
 	exercise_step,
 	wallet::DilithiumScheme,
 };
+use subxt::ext::subxt_core::utils::MultiAddress;
 
 pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Result<()> {
 	exercise_step!(report, phase, "single_transfer", single_transfer(ctx));
@@ -17,6 +18,10 @@ pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Res
 	exercise_step!(report, phase, "transfer_with_tip", transfer_with_tip(ctx));
 	exercise_step!(report, phase, "transfer_manual_nonce", transfer_manual_nonce(ctx));
 	exercise_step!(report, phase, "remark_with_event", remark_with_event(ctx));
+	exercise_step!(report, phase, "transfer_keep_alive", transfer_keep_alive(ctx));
+	exercise_step!(report, phase, "transfer_all", transfer_all(ctx));
+	exercise_step!(report, phase, "burn", burn(ctx));
+	exercise_step!(report, phase, "upgrade_accounts", upgrade_accounts(ctx));
 	exercise_step!(
 		report,
 		phase,
@@ -154,4 +159,95 @@ async fn remark_with_event(ctx: &mut ExerciseCtx) -> Result<String> {
 	let sender = ctx.eph[0].clone();
 	let hash = submit_ok(ctx, &sender, call).await?;
 	Ok(format!("System::remark_with_event included ({hash:?})"))
+}
+
+async fn transfer_keep_alive(ctx: &mut ExerciseCtx) -> Result<String> {
+	let recipient = ctx.fresh_keypair()?;
+	let recipient_id = account_id_of(&recipient)?;
+	let recipient_ss58 = recipient.try_to_account_id_ss58check()?;
+	let amount = ctx.unit;
+
+	let sender = ctx.eph[1].clone();
+	let call = quantus_subxt::api::tx()
+		.balances()
+		.transfer_keep_alive(MultiAddress::Id(recipient_id), amount);
+	submit_ok(ctx, &sender, call).await?;
+
+	let balance = ctx.free_balance(&recipient_ss58).await?;
+	if balance != amount {
+		return Err(QuantusError::Generic(format!(
+			"transfer_keep_alive recipient balance {balance}, expected {amount}"
+		)));
+	}
+	Ok("Balances::transfer_keep_alive included, recipient balance verified".to_string())
+}
+
+/// `transfer_all(keep_alive: false)` must empty and reap the sending account.
+async fn transfer_all(ctx: &mut ExerciseCtx) -> Result<String> {
+	// Dedicated sender so reaping it does not disturb the shared ephemeral accounts.
+	let sender = ctx.fresh_keypair()?;
+	let sender_ss58 = sender.try_to_account_id_ss58check()?;
+	let funder = ctx.eph[1].clone();
+	crate::cli::send::transfer(
+		&ctx.client,
+		&funder,
+		&sender_ss58,
+		20 * ctx.unit,
+		None,
+		ctx.wait_mode(),
+	)
+	.await?;
+
+	let recipient = ctx.fresh_keypair()?;
+	let recipient_ss58 = recipient.try_to_account_id_ss58check()?;
+	let call = quantus_subxt::api::tx()
+		.balances()
+		.transfer_all(MultiAddress::Id(account_id_of(&recipient)?), false);
+	submit_ok(ctx, &sender, call).await?;
+
+	let sender_after = ctx.free_balance(&sender_ss58).await?;
+	if sender_after != 0 {
+		return Err(QuantusError::Generic(format!(
+			"transfer_all left {sender_after} on the sender, expected the account to be emptied"
+		)));
+	}
+	let recipient_after = ctx.free_balance(&recipient_ss58).await?;
+	if recipient_after == 0 {
+		return Err(QuantusError::Generic(
+			"transfer_all recipient received nothing".to_string(),
+		));
+	}
+	Ok(format!(
+		"Balances::transfer_all emptied the sender; recipient received {recipient_after} raw units"
+	))
+}
+
+/// `burn` destroys funds from the caller, reducing total issuance.
+async fn burn(ctx: &mut ExerciseCtx) -> Result<String> {
+	let sender = ctx.eph[0].clone();
+	let sender_ss58 = sender.try_to_account_id_ss58check()?;
+	let amount = ctx.unit;
+
+	let before = ctx.free_balance(&sender_ss58).await?;
+	let call = quantus_subxt::api::tx().balances().burn(amount, true);
+	submit_ok(ctx, &sender, call).await?;
+	let after = ctx.free_balance(&sender_ss58).await?;
+
+	// The exact fee is unknown; the delta must cover at least the burned amount.
+	let delta = before.saturating_sub(after);
+	if delta < amount {
+		return Err(QuantusError::Generic(format!(
+			"burn of {amount} only reduced the sender balance by {delta}"
+		)));
+	}
+	Ok(format!("Balances::burn destroyed {amount} raw units (balance delta {delta} incl. fee)"))
+}
+
+/// `upgrade_accounts` is permissionless maintenance; a no-op call must still dispatch.
+async fn upgrade_accounts(ctx: &mut ExerciseCtx) -> Result<String> {
+	let sender = ctx.eph[1].clone();
+	let target = account_id_of(&ctx.bob)?;
+	let call = quantus_subxt::api::tx().balances().upgrade_accounts(vec![target]);
+	let hash = submit_ok(ctx, &sender, call).await?;
+	Ok(format!("Balances::upgrade_accounts included ({hash:?})"))
 }

--- a/src/cli/exercise/scenarios/balances.rs
+++ b/src/cli/exercise/scenarios/balances.rs
@@ -213,9 +213,7 @@ async fn transfer_all(ctx: &mut ExerciseCtx) -> Result<String> {
 	}
 	let recipient_after = ctx.free_balance(&recipient_ss58).await?;
 	if recipient_after == 0 {
-		return Err(QuantusError::Generic(
-			"transfer_all recipient received nothing".to_string(),
-		));
+		return Err(QuantusError::Generic("transfer_all recipient received nothing".to_string()));
 	}
 	Ok(format!(
 		"Balances::transfer_all emptied the sender; recipient received {recipient_after} raw units"

--- a/src/cli/exercise/scenarios/governance.rs
+++ b/src/cli/exercise/scenarios/governance.rs
@@ -155,10 +155,17 @@ async fn referendum_metadata(ctx: &mut ExerciseCtx) -> Result<String> {
 	// Metadata must reference an on-chain preimage.
 	let metadata: [u8; 32] = rand::Rng::random(&mut ctx.rng);
 	let metadata_hash: sp_core::H256 = BlakeTwo256::hash(&metadata);
-	crate::cli::common::submit_preimage(&ctx.client, &ctx.alice, metadata.to_vec(), ctx.wait_mode())
-		.await?;
+	crate::cli::common::submit_preimage(
+		&ctx.client,
+		&ctx.alice,
+		metadata.to_vec(),
+		ctx.wait_mode(),
+	)
+	.await?;
 
-	let set = quantus_subxt::api::tx().tech_referenda().set_metadata(index, Some(metadata_hash));
+	let set = quantus_subxt::api::tx()
+		.tech_referenda()
+		.set_metadata(index, Some(metadata_hash));
 	submit_ok(ctx, &alice, set).await?;
 
 	let metadata_addr = quantus_subxt::api::storage().tech_referenda().metadata_of(index);

--- a/src/cli/exercise/scenarios/governance.rs
+++ b/src/cli/exercise/scenarios/governance.rs
@@ -15,6 +15,8 @@ use subxt::tx::Payload;
 pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Result<()> {
 	exercise_step!(report, phase, "membership_reads", membership_reads(ctx));
 	exercise_step!(report, phase, "referendum_flow", referendum_flow(ctx));
+	exercise_step!(report, phase, "referendum_metadata", referendum_metadata(ctx));
+	exercise_step!(report, phase, "cleanup_poll", cleanup_poll(ctx));
 	exercise_step!(report, phase, "add_member_requires_root", add_member_requires_root(ctx));
 	Ok(())
 }
@@ -127,6 +129,92 @@ pub fn build_submit_call(preimage_hash: sp_core::H256, call_len: u32) -> impl su
 	quantus_subxt::api::tx()
 		.tech_referenda()
 		.submit(origin_caller, proposal, enactment)
+}
+
+/// Submit a bare referendum (no decision deposit, so it deterministically stays
+/// ongoing even on fast-governance nodes) and drive `set_metadata` plus the
+/// user-callable refund guards against it.
+async fn referendum_metadata(ctx: &mut ExerciseCtx) -> Result<String> {
+	// Proposal preimage for the referendum itself.
+	let marker: [u8; 24] = rand::Rng::random(&mut ctx.rng);
+	let remark = quantus_subxt::api::tx().system().remark(marker.to_vec());
+	let encoded = remark
+		.encode_call_data(&ctx.client.client().metadata())
+		.map_err(|e| QuantusError::Generic(format!("failed to encode remark call: {e:?}")))?;
+	let proposal_hash: sp_core::H256 = BlakeTwo256::hash(&encoded);
+	let call_len = encoded.len() as u32;
+	crate::cli::common::submit_preimage(&ctx.client, &ctx.alice, encoded, ctx.wait_mode()).await?;
+
+	let latest = ctx.client.get_latest_block().await?;
+	let count_addr = quantus_subxt::api::storage().tech_referenda().referendum_count();
+	let index = ctx.client.client().storage().at(latest).fetch(&count_addr).await?.unwrap_or(0);
+
+	let alice = ctx.alice.clone();
+	submit_ok(ctx, &alice, build_submit_call(proposal_hash, call_len)).await?;
+
+	// Metadata must reference an on-chain preimage.
+	let metadata: [u8; 32] = rand::Rng::random(&mut ctx.rng);
+	let metadata_hash: sp_core::H256 = BlakeTwo256::hash(&metadata);
+	crate::cli::common::submit_preimage(&ctx.client, &ctx.alice, metadata.to_vec(), ctx.wait_mode())
+		.await?;
+
+	let set = quantus_subxt::api::tx().tech_referenda().set_metadata(index, Some(metadata_hash));
+	submit_ok(ctx, &alice, set).await?;
+
+	let metadata_addr = quantus_subxt::api::storage().tech_referenda().metadata_of(index);
+	let latest = ctx.client.get_latest_block().await?;
+	let stored = ctx.client.client().storage().at(latest).fetch(&metadata_addr).await?;
+	if stored != Some(metadata_hash) {
+		return Err(QuantusError::Generic(format!(
+			"metadata for referendum #{index} is {stored:?}, expected {metadata_hash:?}"
+		)));
+	}
+
+	let clear = quantus_subxt::api::tx().tech_referenda().set_metadata(index, None);
+	submit_ok(ctx, &alice, clear).await?;
+	let latest = ctx.client.get_latest_block().await?;
+	if ctx.client.client().storage().at(latest).fetch(&metadata_addr).await?.is_some() {
+		return Err(QuantusError::Generic(format!(
+			"metadata for referendum #{index} still present after clearing"
+		)));
+	}
+
+	// User-callable refunds must reject cleanly while the referendum is open:
+	// no decision deposit was placed, and the submission deposit is not
+	// refundable before the referendum closes.
+	let refund_decision = quantus_subxt::api::tx().tech_referenda().refund_decision_deposit(index);
+	submit_expect_failure(ctx, &alice, refund_decision, &["NoDeposit"]).await?;
+	let refund_submission =
+		quantus_subxt::api::tx().tech_referenda().refund_submission_deposit(index);
+	submit_expect_failure(ctx, &alice, refund_submission, &["BadStatus"]).await?;
+
+	Ok(format!(
+		"referendum #{index}: metadata set and cleared (storage verified); \
+		 refund_decision_deposit and refund_submission_deposit rejected while open"
+	))
+}
+
+/// `cleanup_poll` is permissionless: it must reject ongoing polls and dispatch
+/// as a no-op for polls that are not ongoing.
+async fn cleanup_poll(ctx: &mut ExerciseCtx) -> Result<String> {
+	let latest = ctx.client.get_latest_block().await?;
+	let count_addr = quantus_subxt::api::storage().tech_referenda().referendum_count();
+	let count = ctx.client.client().storage().at(latest).fetch(&count_addr).await?.unwrap_or(0);
+
+	// The bare referendum from referendum_metadata (or referendum_flow) is ongoing.
+	let sender = ctx.eph[0].clone();
+	if count > 0 {
+		let ongoing = quantus_subxt::api::tx().tech_collective().cleanup_poll(count - 1, 10);
+		submit_expect_failure(ctx, &sender, ongoing, &["Ongoing"]).await?;
+	}
+
+	// A never-created poll index is not ongoing; cleanup dispatches as a paid no-op.
+	let call = quantus_subxt::api::tx().tech_collective().cleanup_poll(count + 1_000, 10);
+	submit_ok(ctx, &sender, call).await?;
+	Ok(format!(
+		"cleanup_poll rejected for ongoing poll #{} and dispatched for a non-ongoing index",
+		count.saturating_sub(1)
+	))
 }
 
 async fn add_member_requires_root(ctx: &mut ExerciseCtx) -> Result<String> {

--- a/src/cli/exercise/scenarios/mod.rs
+++ b/src/cli/exercise/scenarios/mod.rs
@@ -10,5 +10,6 @@ pub mod reads;
 pub mod recovery;
 pub mod reversible;
 pub mod upgrade;
+pub mod utility;
 pub mod vesting;
 pub mod wormhole;

--- a/src/cli/exercise/scenarios/multisig.rs
+++ b/src/cli/exercise/scenarios/multisig.rs
@@ -13,6 +13,7 @@ use subxt::tx::Payload;
 
 pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Result<()> {
 	exercise_step!(report, phase, "lifecycle", lifecycle(ctx));
+	exercise_step!(report, phase, "expired_proposal_cleanup", expired_proposal_cleanup(ctx));
 	Ok(())
 }
 
@@ -119,6 +120,89 @@ async fn lifecycle(ctx: &mut ExerciseCtx) -> Result<String> {
 	Ok(format!(
 		"2-of-3 multisig {multisig_ss58}: created, funded, proposal #{proposal_id} \
 		 approved+executed (payout verified), proposal #{second_id} cancelled"
+	))
+}
+
+/// Expired proposals must be removable by any signer (`remove_expired`) and
+/// reclaimable in bulk by their proposer (`claim_deposits`).
+async fn expired_proposal_cleanup(ctx: &mut ExerciseCtx) -> Result<String> {
+	let signer_a = ctx.eph[0].clone();
+	let signer_b = ctx.eph[1].clone();
+	let signer_c = ctx.eph[2].clone();
+	let signers =
+		vec![account_id_of(&signer_a)?, account_id_of(&signer_b)?, account_id_of(&signer_c)?];
+	let threshold = 2u32;
+	let nonce: u64 = rand::Rng::random(&mut ctx.rng);
+
+	let create_call =
+		quantus_subxt::api::tx()
+			.multisig()
+			.create_multisig(signers.clone(), threshold, nonce);
+	submit_ok(ctx, &signer_a, create_call).await?;
+	let multisig_ss58 =
+		crate::cli::multisig::predict_multisig_address(signers.clone(), threshold, nonce);
+	let multisig_id = crate::cli::common::resolve_to_subxt_account_id(&multisig_ss58)?;
+
+	// Two proposals with a near-immediate expiry; they are never approved.
+	let inner = quantus_subxt::api::tx().balances().transfer_allow_death(
+		subxt::ext::subxt_core::utils::MultiAddress::Id(account_id_of(&signer_a)?),
+		ctx.unit,
+	);
+	let call_data = inner
+		.encode_call_data(&ctx.client.client().metadata())
+		.map_err(|e| QuantusError::Generic(format!("failed to encode inner call: {e:?}")))?;
+
+	let expiry = current_block(ctx).await? + 3;
+	for proposer in [&signer_a, &signer_b] {
+		let propose_call = quantus_subxt::api::tx().multisig().propose(
+			multisig_id.clone(),
+			quantus_subxt::api::runtime_types::bounded_collections::bounded_vec::BoundedVec(
+				call_data.clone(),
+			),
+			expiry,
+		);
+		submit_ok(ctx, proposer, propose_call).await?;
+	}
+	let proposals = crate::cli::multisig::list_proposals(&ctx.client, multisig_id.clone()).await?;
+	if proposals.len() != 2 {
+		return Err(QuantusError::Generic(format!(
+			"expected 2 pending proposals before expiry, found {}",
+			proposals.len()
+		)));
+	}
+	let first_id = proposals.iter().map(|p| p.id).min().expect("checked non-empty");
+	let second_id = proposals.iter().map(|p| p.id).max().expect("checked non-empty");
+
+	// Wait until the chain is past the expiry block.
+	let deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
+	while current_block(ctx).await? <= expiry {
+		if std::time::Instant::now() > deadline {
+			return Err(QuantusError::Generic(format!(
+				"chain did not pass expiry block {expiry} within 120s"
+			)));
+		}
+		tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+	}
+
+	// Any signer (here signer_c, not the proposer) may sweep an expired proposal.
+	let remove_call =
+		quantus_subxt::api::tx().multisig().remove_expired(multisig_id.clone(), first_id);
+	submit_ok(ctx, &signer_c, remove_call).await?;
+
+	// The proposer reclaims deposits from all remaining expired proposals.
+	let claim_call = quantus_subxt::api::tx().multisig().claim_deposits(multisig_id.clone());
+	submit_ok(ctx, &signer_b, claim_call).await?;
+
+	let remaining = crate::cli::multisig::list_proposals(&ctx.client, multisig_id).await?;
+	if !remaining.is_empty() {
+		return Err(QuantusError::Generic(format!(
+			"{} expired proposal(s) still in storage after cleanup",
+			remaining.len()
+		)));
+	}
+	Ok(format!(
+		"expired proposals cleaned up: #{first_id} via remove_expired (non-proposer signer), \
+		 #{second_id} via claim_deposits (proposer), storage verified"
 	))
 }
 

--- a/src/cli/exercise/scenarios/multisig.rs
+++ b/src/cli/exercise/scenarios/multisig.rs
@@ -185,8 +185,9 @@ async fn expired_proposal_cleanup(ctx: &mut ExerciseCtx) -> Result<String> {
 	}
 
 	// Any signer (here signer_c, not the proposer) may sweep an expired proposal.
-	let remove_call =
-		quantus_subxt::api::tx().multisig().remove_expired(multisig_id.clone(), first_id);
+	let remove_call = quantus_subxt::api::tx()
+		.multisig()
+		.remove_expired(multisig_id.clone(), first_id);
 	submit_ok(ctx, &signer_c, remove_call).await?;
 
 	// The proposer reclaims deposits from all remaining expired proposals.

--- a/src/cli/exercise/scenarios/preimage.rs
+++ b/src/cli/exercise/scenarios/preimage.rs
@@ -4,7 +4,7 @@ use crate::{
 	chain::quantus_subxt,
 	cli::exercise::{
 		report::Report,
-		runner::{submit_expect_failure, ExerciseCtx},
+		runner::{submit_expect_failure, submit_ok, ExerciseCtx},
 	},
 	error::{QuantusError, Result},
 	exercise_step,
@@ -14,7 +14,10 @@ use subxt::tx::Payload;
 
 pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Result<()> {
 	exercise_step!(report, phase, "note_and_verify", note_and_verify(ctx));
+	exercise_step!(report, phase, "unnote_preimage", unnote_preimage(ctx));
+	exercise_step!(report, phase, "ensure_updated", ensure_updated(ctx));
 	exercise_step!(report, phase, "request_requires_root", request_requires_root(ctx));
+	exercise_step!(report, phase, "unrequest_requires_root", unrequest_requires_root(ctx));
 	Ok(())
 }
 
@@ -44,10 +47,67 @@ async fn note_and_verify(ctx: &mut ExerciseCtx) -> Result<String> {
 	}
 }
 
+async fn preimage_status_exists(ctx: &ExerciseCtx, hash: sp_core::H256) -> Result<bool> {
+	let status_addr = quantus_subxt::api::storage().preimage().request_status_for(hash);
+	let latest = ctx.client.get_latest_block().await?;
+	Ok(ctx.client.client().storage().at(latest).fetch(&status_addr).await?.is_some())
+}
+
+/// Note a preimage, then clear it with `unnote_preimage` and verify the
+/// status entry is gone (deposit returned to the noter).
+async fn unnote_preimage(ctx: &mut ExerciseCtx) -> Result<String> {
+	let encoded = unique_remark_call_data(ctx)?;
+	let hash: sp_core::H256 = BlakeTwo256::hash(&encoded);
+
+	let keypair = ctx.eph[3].clone();
+	crate::cli::common::submit_preimage(&ctx.client, &keypair, encoded, ctx.wait_mode()).await?;
+	if !preimage_status_exists(ctx, hash).await? {
+		return Err(QuantusError::Generic(format!(
+			"preimage {hash:?} missing from storage before unnote"
+		)));
+	}
+
+	let call = quantus_subxt::api::tx().preimage().unnote_preimage(hash);
+	submit_ok(ctx, &keypair, call).await?;
+
+	if preimage_status_exists(ctx, hash).await? {
+		return Err(QuantusError::Generic(format!(
+			"preimage {hash:?} still in RequestStatusFor after unnote_preimage"
+		)));
+	}
+	Ok(format!("preimage {hash:?} noted then unnoted, storage entry cleared"))
+}
+
+/// `ensure_updated` is permissionless bulk maintenance; on an already-modern
+/// preimage it performs no migration but must still dispatch successfully.
+async fn ensure_updated(ctx: &mut ExerciseCtx) -> Result<String> {
+	let encoded = unique_remark_call_data(ctx)?;
+	let hash: sp_core::H256 = BlakeTwo256::hash(&encoded);
+	let keypair = ctx.eph[3].clone();
+	crate::cli::common::submit_preimage(&ctx.client, &keypair, encoded, ctx.wait_mode()).await?;
+
+	let call = quantus_subxt::api::tx().preimage().ensure_updated(vec![hash]);
+	submit_ok(ctx, &keypair, call).await?;
+
+	// Clean up the noted preimage so reruns start fresh.
+	let unnote = quantus_subxt::api::tx().preimage().unnote_preimage(hash);
+	submit_ok(ctx, &keypair, unnote).await?;
+	Ok(format!("Preimage::ensure_updated dispatched for already-modern {hash:?}"))
+}
+
 async fn request_requires_root(ctx: &mut ExerciseCtx) -> Result<String> {
 	let encoded = unique_remark_call_data(ctx)?;
 	let hash: sp_core::H256 = BlakeTwo256::hash(&encoded);
 	let call = quantus_subxt::api::tx().preimage().request_preimage(hash);
+	let keypair = ctx.eph[3].clone();
+	submit_expect_failure(ctx, &keypair, call, &["BadOrigin"]).await
+}
+
+/// `unrequest_preimage` is manager-origin only, like `request_preimage`.
+async fn unrequest_requires_root(ctx: &mut ExerciseCtx) -> Result<String> {
+	let encoded = unique_remark_call_data(ctx)?;
+	let hash: sp_core::H256 = BlakeTwo256::hash(&encoded);
+	let call = quantus_subxt::api::tx().preimage().unrequest_preimage(hash);
 	let keypair = ctx.eph[3].clone();
 	submit_expect_failure(ctx, &keypair, call, &["BadOrigin"]).await
 }

--- a/src/cli/exercise/scenarios/recovery.rs
+++ b/src/cli/exercise/scenarios/recovery.rs
@@ -69,24 +69,29 @@ async fn full_lifecycle(ctx: &mut ExerciseCtx) -> Result<String> {
 		(rescuer.try_to_account_id_ss58check()?, funding),
 		(friend.try_to_account_id_ss58check()?, funding),
 	];
-	crate::cli::send::batch_transfer(&ctx.client, &ctx.alice.clone(), transfers, None, ctx.wait_mode())
-		.await?;
+	crate::cli::send::batch_transfer(
+		&ctx.client,
+		&ctx.alice.clone(),
+		transfers,
+		None,
+		ctx.wait_mode(),
+	)
+	.await?;
 
 	let lost_id = account_id_of(&lost)?;
 	let rescuer_id = account_id_of(&rescuer)?;
 	let friend_id = account_id_of(&friend)?;
 
 	// 1. Make `lost` recoverable: one friend, threshold 1, no claim delay.
-	let create = quantus_subxt::api::tx().recovery().create_recovery(
-		vec![friend_id.clone()],
-		1,
-		0,
-	);
+	let create = quantus_subxt::api::tx()
+		.recovery()
+		.create_recovery(vec![friend_id.clone()], 1, 0);
 	submit_ok(ctx, &lost, create).await?;
 
 	// 2. Rescuer starts recovery; 3. friend vouches.
-	let initiate =
-		quantus_subxt::api::tx().recovery().initiate_recovery(MultiAddress::Id(lost_id.clone()));
+	let initiate = quantus_subxt::api::tx()
+		.recovery()
+		.initiate_recovery(MultiAddress::Id(lost_id.clone()));
 	submit_ok(ctx, &rescuer, initiate).await?;
 
 	let vouch = quantus_subxt::api::tx()
@@ -95,8 +100,9 @@ async fn full_lifecycle(ctx: &mut ExerciseCtx) -> Result<String> {
 	submit_ok(ctx, &friend, vouch).await?;
 
 	// 4. Threshold met and delay elapsed (0 blocks): claim the account.
-	let claim =
-		quantus_subxt::api::tx().recovery().claim_recovery(MultiAddress::Id(lost_id.clone()));
+	let claim = quantus_subxt::api::tx()
+		.recovery()
+		.claim_recovery(MultiAddress::Id(lost_id.clone()));
 	submit_ok(ctx, &rescuer, claim).await?;
 
 	if !has_proxy(ctx, &rescuer).await? {
@@ -120,8 +126,9 @@ async fn full_lifecycle(ctx: &mut ExerciseCtx) -> Result<String> {
 			value: drained,
 		})
 	};
-	let as_recovered =
-		quantus_subxt::api::tx().recovery().as_recovered(MultiAddress::Id(lost_id.clone()), inner);
+	let as_recovered = quantus_subxt::api::tx()
+		.recovery()
+		.as_recovered(MultiAddress::Id(lost_id.clone()), inner);
 	submit_ok(ctx, &rescuer, as_recovered).await?;
 
 	let lost_after = ctx.free_balance(&lost_ss58).await?;
@@ -132,8 +139,9 @@ async fn full_lifecycle(ctx: &mut ExerciseCtx) -> Result<String> {
 	}
 
 	// 6. Rescuer gives up proxy access.
-	let cancel =
-		quantus_subxt::api::tx().recovery().cancel_recovered(MultiAddress::Id(lost_id.clone()));
+	let cancel = quantus_subxt::api::tx()
+		.recovery()
+		.cancel_recovered(MultiAddress::Id(lost_id.clone()));
 	submit_ok(ctx, &rescuer, cancel).await?;
 	if has_proxy(ctx, &rescuer).await? {
 		return Err(QuantusError::Generic(
@@ -142,8 +150,9 @@ async fn full_lifecycle(ctx: &mut ExerciseCtx) -> Result<String> {
 	}
 
 	// 7. Owner closes the (claimed) recovery attempt and collects the deposit.
-	let close =
-		quantus_subxt::api::tx().recovery().close_recovery(MultiAddress::Id(rescuer_id.clone()));
+	let close = quantus_subxt::api::tx()
+		.recovery()
+		.close_recovery(MultiAddress::Id(rescuer_id.clone()));
 	submit_ok(ctx, &lost, close).await?;
 
 	// 8. Deposit poke is a paid no-op when nothing changed; must still dispatch.

--- a/src/cli/exercise/scenarios/recovery.rs
+++ b/src/cli/exercise/scenarios/recovery.rs
@@ -1,18 +1,21 @@
-//! Recovery scenarios.
+//! Recovery scenarios: full social-recovery lifecycle plus negative checks.
 
 use crate::{
 	chain::quantus_subxt,
 	cli::exercise::{
 		report::Report,
-		runner::{account_id_of, submit_expect_failure, ExerciseCtx},
+		runner::{account_id_of, submit_expect_failure, submit_ok, ExerciseCtx},
 	},
-	error::Result,
+	error::{QuantusError, Result},
 	exercise_step,
+	wallet::QuantumKeyPair,
 };
+use subxt::ext::subxt_core::utils::MultiAddress;
 
 pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Result<()> {
 	exercise_step!(report, phase, "config_reads", config_reads(ctx));
 	exercise_step!(report, phase, "initiate_not_recoverable", initiate_not_recoverable(ctx));
+	exercise_step!(report, phase, "full_lifecycle", full_lifecycle(ctx));
 	Ok(())
 }
 
@@ -35,9 +38,137 @@ async fn config_reads(ctx: &mut ExerciseCtx) -> Result<String> {
 
 async fn initiate_not_recoverable(ctx: &mut ExerciseCtx) -> Result<String> {
 	let lost = account_id_of(&ctx.bob)?;
-	let call = quantus_subxt::api::tx()
-		.recovery()
-		.initiate_recovery(subxt::ext::subxt_core::utils::MultiAddress::Id(lost));
+	let call = quantus_subxt::api::tx().recovery().initiate_recovery(MultiAddress::Id(lost));
 	let rescuer = ctx.eph[0].clone();
 	submit_expect_failure(ctx, &rescuer, call, &["NotRecoverable"]).await
+}
+
+/// Whether `who` currently has a recovery `Proxy` entry pointing at some account.
+async fn has_proxy(ctx: &ExerciseCtx, who: &QuantumKeyPair) -> Result<bool> {
+	let account = account_id_of(who)?;
+	let latest = ctx.client.get_latest_block().await?;
+	let storage_at = ctx.client.client().storage().at(latest);
+	Ok(storage_at
+		.fetch(&quantus_subxt::api::storage().recovery().proxy(account))
+		.await?
+		.is_some())
+}
+
+/// create → initiate → vouch → claim → as_recovered → cancel_recovered →
+/// close_recovery → poke_deposit → remove_recovery, with storage checks.
+async fn full_lifecycle(ctx: &mut ExerciseCtx) -> Result<String> {
+	// Dedicated accounts so recovery deposits/config never collide with the
+	// shared ephemeral senders used by other phases.
+	let lost = ctx.fresh_keypair()?;
+	let rescuer = ctx.fresh_keypair()?;
+	let friend = ctx.fresh_keypair()?;
+
+	let funding = 200 * ctx.unit;
+	let transfers = vec![
+		(lost.try_to_account_id_ss58check()?, funding),
+		(rescuer.try_to_account_id_ss58check()?, funding),
+		(friend.try_to_account_id_ss58check()?, funding),
+	];
+	crate::cli::send::batch_transfer(&ctx.client, &ctx.alice.clone(), transfers, None, ctx.wait_mode())
+		.await?;
+
+	let lost_id = account_id_of(&lost)?;
+	let rescuer_id = account_id_of(&rescuer)?;
+	let friend_id = account_id_of(&friend)?;
+
+	// 1. Make `lost` recoverable: one friend, threshold 1, no claim delay.
+	let create = quantus_subxt::api::tx().recovery().create_recovery(
+		vec![friend_id.clone()],
+		1,
+		0,
+	);
+	submit_ok(ctx, &lost, create).await?;
+
+	// 2. Rescuer starts recovery; 3. friend vouches.
+	let initiate =
+		quantus_subxt::api::tx().recovery().initiate_recovery(MultiAddress::Id(lost_id.clone()));
+	submit_ok(ctx, &rescuer, initiate).await?;
+
+	let vouch = quantus_subxt::api::tx()
+		.recovery()
+		.vouch_recovery(MultiAddress::Id(lost_id.clone()), MultiAddress::Id(rescuer_id.clone()));
+	submit_ok(ctx, &friend, vouch).await?;
+
+	// 4. Threshold met and delay elapsed (0 blocks): claim the account.
+	let claim =
+		quantus_subxt::api::tx().recovery().claim_recovery(MultiAddress::Id(lost_id.clone()));
+	submit_ok(ctx, &rescuer, claim).await?;
+
+	if !has_proxy(ctx, &rescuer).await? {
+		return Err(QuantusError::Generic(
+			"claim_recovery succeeded but no recovery proxy entry exists".to_string(),
+		));
+	}
+
+	// 5. Dispatch as the recovered account: move funds out of `lost`.
+	// The rescuer signs and pays fees, so the *lost* account's balance is the
+	// one that changes by exactly the transferred amount.
+	let drained = 10 * ctx.unit;
+	let lost_ss58 = lost.try_to_account_id_ss58check()?;
+	let lost_before = ctx.free_balance(&lost_ss58).await?;
+	let inner = {
+		use quantus_subxt::api::runtime_types::{
+			pallet_balances::pallet::Call as BalancesCall, quantus_runtime::RuntimeCall,
+		};
+		RuntimeCall::Balances(BalancesCall::transfer_allow_death {
+			dest: MultiAddress::Id(rescuer_id.clone()),
+			value: drained,
+		})
+	};
+	let as_recovered =
+		quantus_subxt::api::tx().recovery().as_recovered(MultiAddress::Id(lost_id.clone()), inner);
+	submit_ok(ctx, &rescuer, as_recovered).await?;
+
+	let lost_after = ctx.free_balance(&lost_ss58).await?;
+	if lost_after != lost_before - drained {
+		return Err(QuantusError::Generic(format!(
+			"as_recovered transfer not reflected: lost account went {lost_before} -> {lost_after}, expected -{drained}"
+		)));
+	}
+
+	// 6. Rescuer gives up proxy access.
+	let cancel =
+		quantus_subxt::api::tx().recovery().cancel_recovered(MultiAddress::Id(lost_id.clone()));
+	submit_ok(ctx, &rescuer, cancel).await?;
+	if has_proxy(ctx, &rescuer).await? {
+		return Err(QuantusError::Generic(
+			"cancel_recovered succeeded but the proxy entry is still present".to_string(),
+		));
+	}
+
+	// 7. Owner closes the (claimed) recovery attempt and collects the deposit.
+	let close =
+		quantus_subxt::api::tx().recovery().close_recovery(MultiAddress::Id(rescuer_id.clone()));
+	submit_ok(ctx, &lost, close).await?;
+
+	// 8. Deposit poke is a paid no-op when nothing changed; must still dispatch.
+	let poke = quantus_subxt::api::tx().recovery().poke_deposit(None);
+	submit_ok(ctx, &lost, poke).await?;
+
+	// 9. Remove the recovery configuration entirely.
+	let remove = quantus_subxt::api::tx().recovery().remove_recovery();
+	submit_ok(ctx, &lost, remove).await?;
+
+	let latest = ctx.client.get_latest_block().await?;
+	let recoverable = ctx
+		.client
+		.client()
+		.storage()
+		.at(latest)
+		.fetch(&quantus_subxt::api::storage().recovery().recoverable(lost_id))
+		.await?;
+	if recoverable.is_some() {
+		return Err(QuantusError::Generic(
+			"remove_recovery succeeded but the recovery config is still present".to_string(),
+		));
+	}
+
+	Ok("full recovery lifecycle: create, initiate, vouch, claim, as_recovered \
+	    (funds drained), cancel_recovered, close, poke_deposit, remove — storage verified"
+		.to_string())
 }

--- a/src/cli/exercise/scenarios/reversible.rs
+++ b/src/cli/exercise/scenarios/reversible.rs
@@ -217,8 +217,9 @@ async fn guardian_recover_funds(ctx: &mut ExerciseCtx) -> Result<String> {
 		));
 	}
 
-	let recover =
-		quantus_subxt::api::tx().reversible_transfers().recover_funds(account_id_of(&account)?);
+	let recover = quantus_subxt::api::tx()
+		.reversible_transfers()
+		.recover_funds(account_id_of(&account)?);
 	submit_ok(ctx, &ctx.alice.clone(), recover).await?;
 
 	let pending_after = pending_ids(ctx, &account).await?;

--- a/src/cli/exercise/scenarios/reversible.rs
+++ b/src/cli/exercise/scenarios/reversible.rs
@@ -4,16 +4,24 @@ use crate::{
 	chain::quantus_subxt,
 	cli::exercise::{
 		report::Report,
-		runner::{account_id_of, submit_ok, ExerciseCtx},
+		runner::{account_id_of, submit_expect_failure, submit_ok, ExerciseCtx},
 	},
 	error::{QuantusError, Result},
 	exercise_step,
 };
+use rand::Rng;
 
 pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Result<()> {
 	exercise_step!(report, phase, "schedule_and_cancel", schedule_and_cancel(ctx));
 	exercise_step!(report, phase, "schedule_with_delay", schedule_with_delay(ctx));
 	exercise_step!(report, phase, "set_high_security", set_high_security(ctx));
+	exercise_step!(report, phase, "guardian_recover_funds", guardian_recover_funds(ctx));
+	exercise_step!(
+		report,
+		phase,
+		"execute_transfer_wrong_origin",
+		execute_transfer_wrong_origin(ctx)
+	);
 	Ok(())
 }
 
@@ -165,4 +173,78 @@ async fn set_high_security(ctx: &mut ExerciseCtx) -> Result<String> {
 	Ok("high-security enabled (alice as guardian), default-delay transfer scheduled, \
 		 guardian cancelled it, storage verified"
 		.to_string())
+}
+
+/// Guardian seizes a compromised high-security account via `recover_funds`:
+/// pending transfers are cancelled and the whole balance is swept to the guardian.
+async fn guardian_recover_funds(ctx: &mut ExerciseCtx) -> Result<String> {
+	// High-security is sticky; use a dedicated account.
+	let account = ctx.fresh_keypair()?;
+	let account_ss58 = account.try_to_account_id_ss58check()?;
+
+	let funder = ctx.eph[3].clone();
+	crate::cli::send::transfer(
+		&ctx.client,
+		&funder,
+		&account_ss58,
+		20 * ctx.unit,
+		None,
+		ctx.wait_mode(),
+	)
+	.await?;
+
+	let guardian = account_id_of(&ctx.alice)?;
+	use quantus_subxt::api::reversible_transfers::calls::types::set_high_security::Delay;
+	let enroll = quantus_subxt::api::tx()
+		.reversible_transfers()
+		.set_high_security(Delay::BlockNumber(50), guardian);
+	submit_ok(ctx, &account, enroll).await?;
+
+	// Leave a pending transfer behind so recovery also exercises the
+	// cancel-all-pending-holds path.
+	let recipient = ctx.fresh_keypair()?.try_to_account_id_ss58check()?;
+	crate::cli::reversible::schedule_transfer(
+		&ctx.client,
+		&account,
+		&recipient,
+		ctx.unit,
+		ctx.wait_mode(),
+	)
+	.await?;
+	if pending_ids(ctx, &account).await?.is_empty() {
+		return Err(QuantusError::Generic(
+			"pending transfer missing before recover_funds".to_string(),
+		));
+	}
+
+	let recover =
+		quantus_subxt::api::tx().reversible_transfers().recover_funds(account_id_of(&account)?);
+	submit_ok(ctx, &ctx.alice.clone(), recover).await?;
+
+	let pending_after = pending_ids(ctx, &account).await?;
+	if !pending_after.is_empty() {
+		return Err(QuantusError::Generic(format!(
+			"recover_funds left {} pending transfer(s) behind",
+			pending_after.len()
+		)));
+	}
+	let balance_after = ctx.free_balance(&account_ss58).await?;
+	if balance_after != 0 {
+		return Err(QuantusError::Generic(format!(
+			"recover_funds left a free balance of {balance_after} on the recovered account"
+		)));
+	}
+	Ok("guardian recovered high-security account: pending transfer seized, \
+	    full balance swept to guardian, storage verified"
+		.to_string())
+}
+
+/// `execute_transfer` is only dispatchable by the pallet's own scheduler origin;
+/// an external signed call must be rejected.
+async fn execute_transfer_wrong_origin(ctx: &mut ExerciseCtx) -> Result<String> {
+	let sender = ctx.eph[2].clone();
+	let tx_id = subxt::utils::H256::from(ctx.rng.random::<[u8; 32]>());
+	let call = quantus_subxt::api::tx().reversible_transfers().execute_transfer(tx_id);
+	submit_expect_failure(ctx, &sender, call, &["InvalidSchedulerOrigin", "PendingTxNotFound"])
+		.await
 }

--- a/src/cli/exercise/scenarios/utility.rs
+++ b/src/cli/exercise/scenarios/utility.rs
@@ -1,0 +1,155 @@
+//! Utility pallet scenarios: force_batch, if_else, as_derivative.
+//!
+//! `Utility::batch` is covered by the fuzz phase and `batch_all` backs every
+//! CLI batch transfer; `dispatch_as`, `dispatch_as_fallible`, and `with_weight`
+//! are root-only and unreachable from the outside.
+
+use crate::{
+	chain::quantus_subxt,
+	cli::exercise::{
+		report::Report,
+		runner::{account_id_of, submit_ok, ExerciseCtx},
+	},
+	error::{QuantusError, Result},
+	exercise_step,
+};
+use codec::Encode;
+use quantus_subxt::api::runtime_types::{
+	pallet_balances::pallet::Call as BalancesCall, quantus_runtime::RuntimeCall,
+};
+use subxt::ext::subxt_core::utils::MultiAddress;
+
+pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Result<()> {
+	exercise_step!(report, phase, "force_batch_partial_failure", force_batch_partial(ctx));
+	exercise_step!(report, phase, "if_else_fallback", if_else_fallback(ctx));
+	exercise_step!(report, phase, "as_derivative", as_derivative(ctx));
+	Ok(())
+}
+
+fn transfer_call(dest: crate::cli::common::SubxtAccountId32, value: u128) -> RuntimeCall {
+	RuntimeCall::Balances(BalancesCall::transfer_allow_death {
+		dest: MultiAddress::Id(dest),
+		value,
+	})
+}
+
+/// An impossible transfer amount, guaranteeing the call fails while staying
+/// syntactically valid.
+const ABSURD_AMOUNT: u128 = u128::MAX / 2;
+
+/// `force_batch` keeps executing after an item fails; the good item must land.
+async fn force_batch_partial(ctx: &mut ExerciseCtx) -> Result<String> {
+	let sender = ctx.eph[0].clone();
+	let good_recipient = ctx.fresh_keypair()?;
+	let good_ss58 = good_recipient.try_to_account_id_ss58check()?;
+	let failing_recipient = ctx.fresh_keypair()?;
+	let amount = ctx.unit;
+
+	let calls = vec![
+		transfer_call(account_id_of(&good_recipient)?, amount),
+		transfer_call(account_id_of(&failing_recipient)?, ABSURD_AMOUNT),
+	];
+	let call = quantus_subxt::api::tx().utility().force_batch(calls);
+	submit_ok(ctx, &sender, call).await?;
+
+	let good_balance = ctx.free_balance(&good_ss58).await?;
+	if good_balance != amount {
+		return Err(QuantusError::Generic(format!(
+			"force_batch good item not applied: recipient has {good_balance}, expected {amount}"
+		)));
+	}
+	let failing_balance =
+		ctx.free_balance(&failing_recipient.try_to_account_id_ss58check()?).await?;
+	if failing_balance != 0 {
+		return Err(QuantusError::Generic(format!(
+			"force_batch failing item unexpectedly transferred {failing_balance}"
+		)));
+	}
+	Ok("Utility::force_batch survived a failing item; good transfer verified".to_string())
+}
+
+/// `if_else` dispatches the fallback when the main call fails.
+async fn if_else_fallback(ctx: &mut ExerciseCtx) -> Result<String> {
+	let sender = ctx.eph[1].clone();
+	let recipient = ctx.fresh_keypair()?;
+	let recipient_ss58 = recipient.try_to_account_id_ss58check()?;
+	let amount = ctx.unit;
+
+	let main = transfer_call(account_id_of(&recipient)?, ABSURD_AMOUNT);
+	let fallback = transfer_call(account_id_of(&recipient)?, amount);
+	let call = quantus_subxt::api::tx().utility().if_else(main, fallback);
+	submit_ok(ctx, &sender, call).await?;
+
+	let balance = ctx.free_balance(&recipient_ss58).await?;
+	if balance != amount {
+		return Err(QuantusError::Generic(format!(
+			"if_else fallback not applied: recipient has {balance}, expected {amount}"
+		)));
+	}
+	Ok("Utility::if_else main call failed, fallback transfer executed and verified".to_string())
+}
+
+/// Derivative (pseudonym) account of `who` at `index`, as computed by
+/// `pallet_utility::derivative_account_id`.
+fn derivative_account(
+	who: &crate::cli::common::SubxtAccountId32,
+	index: u16,
+) -> crate::cli::common::SubxtAccountId32 {
+	let who_bytes: &[u8; 32] = who.as_ref();
+	let entropy = sp_core::hashing::blake2_256(&(b"modlpy/utilisuba", who_bytes, index).encode());
+	crate::cli::common::SubxtAccountId32::from(entropy)
+}
+
+fn to_ss58(account: &crate::cli::common::SubxtAccountId32) -> String {
+	use sp_core::crypto::Ss58Codec;
+	let bytes: [u8; 32] = *account.as_ref();
+	sp_core::crypto::AccountId32::from(bytes)
+		.to_ss58check_with_version(sp_core::crypto::Ss58AddressFormat::custom(189))
+}
+
+/// `as_derivative` must dispatch the inner call from the caller's derivative
+/// account, not from the caller itself.
+async fn as_derivative(ctx: &mut ExerciseCtx) -> Result<String> {
+	let sender = ctx.eph[2].clone();
+	let index: u16 = 42;
+	let derivative = derivative_account(&account_id_of(&sender)?, index);
+	let derivative_ss58 = to_ss58(&derivative);
+
+	// The derivative account has to hold the funds the inner call moves.
+	let funding = 5 * ctx.unit;
+	crate::cli::send::transfer(
+		&ctx.client,
+		&sender,
+		&derivative_ss58,
+		funding,
+		None,
+		ctx.wait_mode(),
+	)
+	.await?;
+
+	let recipient = ctx.fresh_keypair()?;
+	let recipient_ss58 = recipient.try_to_account_id_ss58check()?;
+	let amount = 2 * ctx.unit;
+	let inner = transfer_call(account_id_of(&recipient)?, amount);
+	let call = quantus_subxt::api::tx().utility().as_derivative(index, inner);
+	submit_ok(ctx, &sender, call).await?;
+
+	let received = ctx.free_balance(&recipient_ss58).await?;
+	if received != amount {
+		return Err(QuantusError::Generic(format!(
+			"as_derivative transfer not applied: recipient has {received}, expected {amount}"
+		)));
+	}
+	let derivative_after = ctx.free_balance(&derivative_ss58).await?;
+	if derivative_after != funding - amount {
+		return Err(QuantusError::Generic(format!(
+			"derivative account balance is {derivative_after}, expected {} — the inner \
+			 call did not draw from the derivative account",
+			funding - amount
+		)));
+	}
+	Ok(format!(
+		"Utility::as_derivative (index {index}) transferred from the derivative account; \
+		 both balances verified"
+	))
+}

--- a/src/cli/exercise/scenarios/wormhole.rs
+++ b/src/cli/exercise/scenarios/wormhole.rs
@@ -8,22 +8,26 @@ use crate::{
 };
 
 pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Result<()> {
+	// Split the two runs across both signature schemes *and* both wormhole
+	// extrinsics: the private run submits Wormhole::verify_private_batch, the
+	// public run wraps each round in a public batch and submits
+	// Wormhole::verify_public_batch.
 	exercise_step!(
 		report,
 		phase,
-		"multiround_ml_dsa_65",
-		multiround(ctx, DilithiumScheme::MlDsa65)
+		"multiround_private_ml_dsa_65",
+		multiround(ctx, DilithiumScheme::MlDsa65, false)
 	);
 	exercise_step!(
 		report,
 		phase,
-		"multiround_ml_dsa_87",
-		multiround(ctx, DilithiumScheme::MlDsa87)
+		"multiround_public_ml_dsa_87",
+		multiround(ctx, DilithiumScheme::MlDsa87, true)
 	);
 	Ok(())
 }
 
-async fn multiround(ctx: &mut ExerciseCtx, scheme: DilithiumScheme) -> Result<String> {
+async fn multiround(ctx: &mut ExerciseCtx, scheme: DilithiumScheme, public: bool) -> Result<String> {
 	// Dev wallets (crystal_*) have no mnemonic; wormhole HD derivation requires one.
 	let wallet_name = format!("exercise_wormhole_{}_{}", scheme, ctx.seed);
 	let manager = WalletManager::new()?;
@@ -54,7 +58,7 @@ async fn multiround(ctx: &mut ExerciseCtx, scheme: DilithiumScheme) -> Result<St
 			ctx.wait_mode(),
 		)
 		.await?;
-		run_multiround_command(ctx, &wallet_name, scheme).await
+		run_multiround_command(ctx, &wallet_name, scheme, public).await
 	}
 	.await;
 
@@ -75,6 +79,7 @@ async fn run_multiround_command(
 	ctx: &ExerciseCtx,
 	wallet_name: &str,
 	scheme: DilithiumScheme,
+	public: bool,
 ) -> Result<String> {
 	let command = crate::cli::wormhole::WormholeCommands::Multiround {
 		num_proofs: 5,
@@ -86,8 +91,9 @@ async fn run_multiround_command(
 		keep_files: false,
 		output_dir: format!("/tmp/wormhole_exercise_{}_{}", scheme, ctx.seed),
 		dry_run: false,
-		public: false,
+		public,
 	};
 	crate::cli::wormhole::handle_wormhole_command(command, &ctx.node_url, ctx.wait_mode()).await?;
-	Ok(format!("wormhole multiround ({scheme}; 5 rounds, 5 proofs each) completed"))
+	let extrinsic = if public { "verify_public_batch" } else { "verify_private_batch" };
+	Ok(format!("wormhole multiround ({scheme}; 5 rounds, 5 proofs each, {extrinsic}) completed"))
 }

--- a/src/cli/exercise/scenarios/wormhole.rs
+++ b/src/cli/exercise/scenarios/wormhole.rs
@@ -27,7 +27,11 @@ pub async fn run(ctx: &mut ExerciseCtx, report: &mut Report, phase: &str) -> Res
 	Ok(())
 }
 
-async fn multiround(ctx: &mut ExerciseCtx, scheme: DilithiumScheme, public: bool) -> Result<String> {
+async fn multiround(
+	ctx: &mut ExerciseCtx,
+	scheme: DilithiumScheme,
+	public: bool,
+) -> Result<String> {
 	// Dev wallets (crystal_*) have no mnemonic; wormhole HD derivation requires one.
 	let wallet_name = format!("exercise_wormhole_{}_{}", scheme, ctx.seed);
 	let manager = WalletManager::new()?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,6 +22,7 @@ pub const COMPATIBLE_RUNTIMES: &[CompatibleRuntime] = &[
 	CompatibleRuntime { spec_version: 135, transaction_version: 3, supports_ml_dsa_65: false },
 	CompatibleRuntime { spec_version: 136, transaction_version: 3, supports_ml_dsa_65: false },
 	CompatibleRuntime { spec_version: 142, transaction_version: 3, supports_ml_dsa_65: true },
+	CompatibleRuntime { spec_version: 143, transaction_version: 3, supports_ml_dsa_65: true },
 ];
 
 /// Check whether a runtime version pair is supported by this CLI.
@@ -96,7 +97,9 @@ mod tests {
 		validate_runtime_identity(EXPECTED_RUNTIME_SPEC_NAME, 136, 3)
 			.expect("compatible quantus runtime must be accepted");
 		validate_runtime_identity(EXPECTED_RUNTIME_SPEC_NAME, 142, 3)
-			.expect("the current vesting-enabled runtime must be accepted");
+			.expect("vesting-enabled runtime must be accepted");
+		validate_runtime_identity(EXPECTED_RUNTIME_SPEC_NAME, 143, 3)
+			.expect("the current runtime must be accepted");
 	}
 
 	/// Pinned to the spec name the real Quantus runtime declares
@@ -162,6 +165,7 @@ mod tests {
 		assert!(!runtime_supports_ml_dsa_65(135, 3));
 		assert!(!runtime_supports_ml_dsa_65(136, 3));
 		assert!(runtime_supports_ml_dsa_65(142, 3));
+		assert!(runtime_supports_ml_dsa_65(143, 3));
 		assert!(!runtime_supports_ml_dsa_65(142, 2), "unknown tx version must not match");
 	}
 
@@ -174,6 +178,7 @@ mod tests {
 			"expected actionable ML-DSA-65 gate error, got: {msg}"
 		);
 		ensure_ml_dsa_65_supported(142, 3).expect("142 must allow ML-DSA-65");
+		ensure_ml_dsa_65_supported(143, 3).expect("143 must allow ML-DSA-65");
 	}
 
 	#[test]


### PR DESCRIPTION
# Accept spec 143, expand exercise extrinsic coverage, fix public-batch sizing

## Summary

This PR does three things:

1. **Accepts runtime spec 143 / transaction version 3** as a compatible runtime.
2. **Expands the `quantus exercise` suite** to cover every externally reachable
   extrinsic in the Recovery, Wormhole, ReversibleTransfers, Balances, Multisig,
   Preimage, TechCollective/TechReferenda, and Utility pallets, one commit per
   pallet.
3. **Fixes two wormhole artifact issues**, one of which was caught by the new
   coverage: CLI-generated public-batch proofs were rejected on-chain because
   the CLI still sized the public-batch circuit for 4 private batches while the
   chain's default moved to 53.

## Exercise coverage, by pallet

Each area is a separate commit. Root-only extrinsics (`force_*`, `dispatch_as`,
`with_weight`, `nudge_referendum`, …) are intentionally excluded, except where a
cheap `BadOrigin` guard is worth asserting.

### Recovery (`669e6bf`)
Full social-recovery lifecycle against dedicated funded accounts:
`create_recovery` → `initiate_recovery` → `vouch_recovery` → `claim_recovery` →
`as_recovered` (drains funds from the lost account, balance verified) →
`cancel_recovered` → `close_recovery` → `poke_deposit` → `remove_recovery`,
with proxy/config storage checks at each transition.

### Wormhole (`a63626d`)
The two multiround runs now split across both signature schemes *and* both
wormhole extrinsics: the ML-DSA-65 run submits `verify_private_batch`, and the
ML-DSA-87 run wraps each round in a public batch and submits
`verify_public_batch`.

### ReversibleTransfers (`83b7042`)
- `guardian_recover_funds`: high-security enrollment, a pending transfer left
  behind, then the guardian calls `recover_funds` — pending holds seized, the
  full balance swept to the guardian, storage verified.
- `execute_transfer` is scheduler-origin-only; an external signed call is
  asserted to fail with `InvalidSchedulerOrigin`.

### Balances (`ee787a3`)
- `transfer_keep_alive` (recipient balance verified)
- `transfer_all` with `keep_alive: false` on a dedicated sender — the account
  must be emptied and reaped
- `burn` (sender delta covers the burned amount)
- permissionless `upgrade_accounts` no-op dispatch

### Multisig (`24a4660`)
`expired_proposal_cleanup`: two proposals with a 3-block expiry are left
unapproved; after expiry a **non-proposer** signer removes one via
`remove_expired` and the proposer bulk-reclaims the other via `claim_deposits`,
with storage verified empty afterwards.

### Preimage (`079521b`)
- `unnote_preimage`: note → verify → unnote → verify cleared
- permissionless `ensure_updated` dispatch on an already-modern preimage
- `unrequest_preimage` rejects non-manager origins (mirrors the existing
  `request_preimage` guard)

### TechCollective / TechReferenda (`b49b0a2`)
- `referendum_metadata`: a bare referendum (no decision deposit, so it
  deterministically stays open even on fast-governance nodes) drives
  `set_metadata` set/clear with storage checks, plus rejection guards for
  `refund_decision_deposit` (`NoDeposit`) and `refund_submission_deposit`
  (`BadStatus`) while the referendum is open. (The positive refund path already
  runs in the upgrade phase.)
- `cleanup_poll`: rejected with `Ongoing` for a live poll, and dispatched as a
  permissionless no-op for a non-ongoing index.

### Utility (`59e0183`) — new `utility` phase
- `force_batch` keeps executing past a failing item; the good transfer lands
  and the failing one does not
- `if_else` dispatches the fallback when the main call fails
- `as_derivative` provably spends from the caller's derivative account
  (address computed like `pallet_utility::derivative_account_id`, both
  balances asserted)

`batch`/`batch_all` were already covered by the fuzz phase and the CLI's batch
transfers.

## Wormhole artifact fixes

### Public-batch sizing mismatch (`bc1c558`) — found by the new coverage
The runtime bakes `NUM_PRIVATE_BATCH_PROOFS` into its public-batch verifier and
its build default moved from 4 to **53** alongside the 4-bps volume fee. The CLI
still generated public-batch circuits sized for 4, so every CLI-produced public
batch verified locally but was rejected on-chain as `Invalid Transaction (1010)`.
`DEFAULT_NUM_PRIVATE_BATCH_PROOFS` is now 53; the regenerated
`public_batch_verifier.bin` hash matches the chain's build artifacts exactly,
and existing artifact directories quarantine-and-regenerate automatically via
the manifest sizing check.

### `QUANTUS_BINS_DIR` no longer required (`387ea0f`)
Circuit-binary resolution now defaults to `~/.quantus/generated-bins` and
regenerates on demand. `./generated-bins` in the CWD is never trusted
implicitly (an attacker-prepared checkout could ship a self-consistent
artifact set) — it is only used when explicitly selected via
`QUANTUS_BINS_DIR`.

## Test plan

All validated against a live local node (`ws://127.0.0.1:9944`, spec 143):

- [x] `exercise --phases recovery` — 5/5 passed
- [x] `exercise --phases balances,utility,reversible,multisig,preimage,governance` — 33/33 passed
- [x] `exercise --phases wormhole` — 4/4 passed (private 210s, public 430s; the
      53-slot public aggregation is heavier, as expected)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `SKIP_CIRCUIT_BUILD=1 cargo test --locked --lib` — 243 passed