### PR TITLE
exercise: add --self-upgrade smoke test for the runtime upgrade path

### DIFF
--- a/src/cli/exercise/mod.rs
+++ b/src/cli/exercise/mod.rs
@@ -36,6 +36,14 @@ pub struct ExerciseArgs {
 	#[arg(long)]
 	pub upgrade_wasm: Option<PathBuf>,
 
+	/// Self-upgrade smoke test: re-install the current on-chain runtime via
+	/// `authorize_upgrade_without_checks` + `apply_authorized_upgrade` (the
+	/// blob is too large for a referendum Lookup). Enables the upgrade phase;
+	/// requires a fast-governance node. Does not re-run other phases afterwards
+	/// (the runtime is unchanged).
+	#[arg(long, conflicts_with = "upgrade_wasm")]
+	pub self_upgrade: bool,
+
 	#[arg(long, default_value_t = 900)]
 	pub upgrade_timeout_secs: u64,
 
@@ -107,15 +115,15 @@ impl Phase {
 pub async fn handle_exercise_command(args: ExerciseArgs, node_url: &str) -> Result<()> {
 	let seed = args.seed.unwrap_or_else(rand::random);
 	let mut selected = args.phases.clone().unwrap_or_else(Phase::default_set);
-	if args.upgrade_wasm.is_some() && !selected.contains(&Phase::Upgrade) {
+	if (args.upgrade_wasm.is_some() || args.self_upgrade) && !selected.contains(&Phase::Upgrade) {
 		selected.push(Phase::Upgrade);
 	}
 	if let Some(skip) = &args.skip {
 		selected.retain(|p| !skip.contains(p));
 	}
-	if selected.contains(&Phase::Upgrade) && args.upgrade_wasm.is_none() {
+	if selected.contains(&Phase::Upgrade) && args.upgrade_wasm.is_none() && !args.self_upgrade {
 		return Err(QuantusError::Generic(
-			"the upgrade phase requires --upgrade-wasm <path>".to_string(),
+			"the upgrade phase requires --upgrade-wasm <path> or --self-upgrade".to_string(),
 		));
 	}
 
@@ -153,23 +161,36 @@ pub async fn handle_exercise_command(args: ExerciseArgs, node_url: &str) -> Resu
 	run_phases(&mut ctx, &mut report, &selected, "").await?;
 
 	if selected.contains(&Phase::Upgrade) && !report.should_abort() {
-		let wasm = args.upgrade_wasm.clone().expect("checked above");
-		scenarios::upgrade::run(&mut ctx, &mut report, "upgrade", &wasm, args.upgrade_timeout_secs)
+		let mode = match args.upgrade_wasm.clone() {
+			Some(wasm) => scenarios::upgrade::UpgradeMode::SetCode(wasm),
+			None => scenarios::upgrade::UpgradeMode::SelfNoop,
+		};
+		let is_real_upgrade = matches!(mode, scenarios::upgrade::UpgradeMode::SetCode(_));
+		scenarios::upgrade::run(&mut ctx, &mut report, "upgrade", mode, args.upgrade_timeout_secs)
 			.await?;
 
-		let upgrade_ok = report
-			.steps
-			.iter()
-			.filter(|s| s.phase == "upgrade")
-			.all(|s| s.status == report::StepStatus::Passed);
-		if upgrade_ok {
-			crate::log_status!("🔁 Re-running phases against the upgraded runtime…");
-			ctx.client = QuantusClient::new(node_url).await?;
-			let rerun: Vec<Phase> =
-				selected.iter().copied().filter(|p| *p != Phase::Upgrade).collect();
-			run_phases(&mut ctx, &mut report, &rerun, "post-upgrade:").await?;
-		} else {
-			report.record_skip("post-upgrade", "rerun", "skipped because the upgrade phase failed");
+		// Only a real set_code upgrade changes the runtime; the self-upgrade
+		// no-op re-installs the same blob, so a post-upgrade re-run would just
+		// burn time without covering any new code path.
+		if is_real_upgrade {
+			let upgrade_ok = report
+				.steps
+				.iter()
+				.filter(|s| s.phase == "upgrade")
+				.all(|s| s.status == report::StepStatus::Passed);
+			if upgrade_ok {
+				crate::log_status!("🔁 Re-running phases against the upgraded runtime…");
+				ctx.client = QuantusClient::new(node_url).await?;
+				let rerun: Vec<Phase> =
+					selected.iter().copied().filter(|p| *p != Phase::Upgrade).collect();
+				run_phases(&mut ctx, &mut report, &rerun, "post-upgrade:").await?;
+			} else {
+				report.record_skip(
+					"post-upgrade",
+					"rerun",
+					"skipped because the upgrade phase failed",
+				);
+			}
 		}
 	}
 

--- a/src/cli/exercise/scenarios/upgrade.rs
+++ b/src/cli/exercise/scenarios/upgrade.rs
@@ -1,4 +1,17 @@
-//! Runtime upgrade via tech-referenda set_code (requires fast-governance node).
+//! Runtime upgrade via tech-referenda (requires fast-governance node).
+//!
+//! Two modes:
+//! - `SetCode(wasm)`: a real upgrade via `system.set_code`; requires a candidate WASM with a higher
+//!   `spec_version` and verifies the spec bump.
+//! - `SelfNoop`: fetches the current on-chain `:code` and re-installs it.
+//!   `frame_system::can_set_code` would reject the identical blob (`SpecVersionNeedsToIncrease`),
+//!   so the unchecked variants are used; the version-comparison logic itself is trivial and not
+//!   worth building a bumped WASM for. The code blob exceeds `TechReferenda::MaxProposalSize`, so
+//!   the referendum approves a 32-byte `system.authorize_upgrade_without_checks` hash and the full
+//!   code is then supplied by anyone via `system.apply_authorized_upgrade`. This proves the whole
+//!   upgrade pipeline — referendum with Root origin, enactment, authorization, code storage write —
+//!   and success is detected via the `System::CodeUpdated` event since the spec version stays the
+//!   same.
 
 use crate::{
 	chain::quantus_subxt,
@@ -10,28 +23,159 @@ use crate::{
 	exercise_step,
 };
 use sp_runtime::traits::{BlakeTwo256, Hash};
-use std::path::Path;
+use std::path::PathBuf;
 use subxt::tx::Payload;
+
+pub enum UpgradeMode {
+	/// Real upgrade: `system.set_code` with the given candidate WASM.
+	SetCode(PathBuf),
+	/// No-op self-upgrade: re-install the current on-chain code via
+	/// `authorize_upgrade_without_checks` + `apply_authorized_upgrade`.
+	SelfNoop,
+}
 
 pub async fn run(
 	ctx: &mut ExerciseCtx,
 	report: &mut Report,
 	phase: &str,
-	wasm_path: &Path,
+	mode: UpgradeMode,
 	timeout_secs: u64,
 ) -> Result<()> {
-	exercise_step!(
-		report,
-		phase,
-		"governance_set_code",
-		governance_set_code(ctx, wasm_path, timeout_secs)
-	);
+	match mode {
+		UpgradeMode::SetCode(wasm_path) => {
+			exercise_step!(
+				report,
+				phase,
+				"governance_set_code",
+				governance_set_code(ctx, &wasm_path, timeout_secs)
+			);
+		},
+		UpgradeMode::SelfNoop => {
+			exercise_step!(
+				report,
+				phase,
+				"governance_self_upgrade",
+				governance_self_upgrade(ctx, timeout_secs)
+			);
+		},
+	}
 	Ok(())
+}
+
+/// Note `encoded_call` as a preimage and drive it through a Root-origin
+/// tech-referendum: submit, place the decision deposit, and vote aye with the
+/// three dev genesis accounts. Returns the referendum index.
+async fn submit_root_referendum(ctx: &mut ExerciseCtx, encoded_call: Vec<u8>) -> Result<u32> {
+	let preimage_hash: sp_core::H256 = BlakeTwo256::hash(&encoded_call);
+	let call_len = encoded_call.len() as u32;
+	crate::cli::common::submit_preimage(&ctx.client, &ctx.alice, encoded_call, ctx.wait_mode())
+		.await?;
+
+	let latest = ctx.client.get_latest_block().await?;
+	let count_addr = quantus_subxt::api::storage().tech_referenda().referendum_count();
+	let index = ctx.client.client().storage().at(latest).fetch(&count_addr).await?.unwrap_or(0);
+
+	let submit_call =
+		crate::cli::exercise::scenarios::governance::build_submit_call(preimage_hash, call_len);
+	let alice = ctx.alice.clone();
+	submit_ok(ctx, &alice, submit_call).await?;
+	crate::log_status!("⬆️  Referendum #{index} submitted");
+
+	let deposit_call = quantus_subxt::api::tx().tech_referenda().place_decision_deposit(index);
+	submit_ok(ctx, &alice, deposit_call).await?;
+
+	// Cast all three ayes in parallel. Under `fast-governance` the decision
+	// window is only 2 blocks; waiting for inclusion between sequential votes
+	// lets the poll close mid-loop (`TechCollective::NotPolling`).
+	cast_collective_ayes(ctx, index).await?;
+	crate::log_status!("⬆️  Decision deposit placed and 3 aye votes cast; waiting for enactment…");
+	Ok(index)
+}
+
+/// Vote aye from alice/bob/charlie concurrently. A `NotPolling` error is
+/// tolerated when the referendum has already been approved (confirm period
+/// elapsed between the parallel submissions).
+async fn cast_collective_ayes(ctx: &ExerciseCtx, index: u32) -> Result<()> {
+	let client = &ctx.client;
+	let alice = ctx.alice.clone();
+	let bob = ctx.bob.clone();
+	let charlie = ctx.charlie.clone();
+	let mode = ctx.wait_mode();
+
+	let (r_a, r_b, r_c) = tokio::join!(
+		crate::cli::tech_collective::vote_on_referendum(client, &alice, index, true, mode),
+		crate::cli::tech_collective::vote_on_referendum(client, &bob, index, true, mode),
+		crate::cli::tech_collective::vote_on_referendum(client, &charlie, index, true, mode),
+	);
+
+	let mut failures = Vec::new();
+	for (who, result) in [("alice", r_a), ("bob", r_b), ("charlie", r_c)] {
+		if let Err(e) = result {
+			failures.push((who, e));
+		}
+	}
+	if failures.is_empty() {
+		return Ok(());
+	}
+
+	if referendum_is_approved(ctx, index).await? {
+		crate::log_status!(
+			"⬆️  Referendum #{index} already approved; ignoring {} vote(s) that raced the close \
+			 ({})",
+			failures.len(),
+			failures
+				.iter()
+				.map(|(who, e)| format!("{who}: {e}"))
+				.collect::<Vec<_>>()
+				.join("; ")
+		);
+		return Ok(());
+	}
+
+	let detail = failures
+		.into_iter()
+		.map(|(who, e)| format!("{who}: {e}"))
+		.collect::<Vec<_>>()
+		.join("; ");
+	Err(QuantusError::Generic(format!(
+		"collective aye votes failed on referendum #{index} (and it is not yet approved): {detail}"
+	)))
+}
+
+async fn referendum_is_approved(ctx: &ExerciseCtx, index: u32) -> Result<bool> {
+	use quantus_subxt::api::runtime_types::pallet_referenda::types::ReferendumInfo;
+	let info_addr = quantus_subxt::api::storage().tech_referenda().referendum_info_for(index);
+	let latest = ctx.client.get_latest_block().await?;
+	Ok(matches!(
+		ctx.client.client().storage().at(latest).fetch(&info_addr).await?,
+		Some(ReferendumInfo::Approved(..))
+	))
+}
+
+/// Best-effort refund of the referendum's submission and decision deposits.
+async fn refund_deposits(ctx: &mut ExerciseCtx, index: u32) -> &'static str {
+	let alice = ctx.alice.clone();
+	let refund_decision = quantus_subxt::api::tx().tech_referenda().refund_decision_deposit(index);
+	let refund_submission =
+		quantus_subxt::api::tx().tech_referenda().refund_submission_deposit(index);
+	let refund_result_a = submit_ok(ctx, &alice, refund_decision).await;
+	let refund_result_b = submit_ok(ctx, &alice, refund_submission).await;
+	match (refund_result_a, refund_result_b) {
+		(Ok(_), Ok(_)) => "deposits refunded",
+		_ => "deposit refund not yet available (referendum bookkeeping pending)",
+	}
+}
+
+async fn referendum_state(ctx: &ExerciseCtx, index: u32) -> Result<String> {
+	let info_addr = quantus_subxt::api::storage().tech_referenda().referendum_info_for(index);
+	let latest = ctx.client.get_latest_block().await?;
+	let info = ctx.client.client().storage().at(latest).fetch(&info_addr).await?;
+	Ok(format!("{info:?}"))
 }
 
 async fn governance_set_code(
 	ctx: &mut ExerciseCtx,
-	wasm_path: &Path,
+	wasm_path: &std::path::Path,
 	timeout_secs: u64,
 ) -> Result<String> {
 	let (spec_before, _) = ctx.client.get_runtime_version().await?;
@@ -50,64 +194,150 @@ async fn governance_set_code(
 	let encoded = set_code
 		.encode_call_data(&ctx.client.client().metadata())
 		.map_err(|e| QuantusError::Generic(format!("failed to encode set_code: {e:?}")))?;
-	let preimage_hash: sp_core::H256 = BlakeTwo256::hash(&encoded);
-	let call_len = encoded.len() as u32;
-	crate::cli::common::submit_preimage(&ctx.client, &ctx.alice, encoded, ctx.wait_mode()).await?;
-
-	let latest = ctx.client.get_latest_block().await?;
-	let count_addr = quantus_subxt::api::storage().tech_referenda().referendum_count();
-	let index = ctx.client.client().storage().at(latest).fetch(&count_addr).await?.unwrap_or(0);
-
-	let submit_call =
-		crate::cli::exercise::scenarios::governance::build_submit_call(preimage_hash, call_len);
-	let alice = ctx.alice.clone();
-	submit_ok(ctx, &alice, submit_call).await?;
-	crate::log_status!("⬆️  Referendum #{index} submitted");
-
-	let deposit_call = quantus_subxt::api::tx().tech_referenda().place_decision_deposit(index);
-	submit_ok(ctx, &alice, deposit_call).await?;
-
-	for voter in [ctx.alice.clone(), ctx.bob.clone(), ctx.charlie.clone()] {
-		crate::cli::tech_collective::vote_on_referendum(
-			&ctx.client,
-			&voter,
-			index,
-			true,
-			ctx.wait_mode(),
-		)
-		.await?;
-	}
-	crate::log_status!("⬆️  Decision deposit placed and 3 aye votes cast; waiting for enactment…");
+	let index = submit_root_referendum(ctx, encoded).await?;
 
 	let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 	loop {
 		tokio::time::sleep(std::time::Duration::from_secs(6)).await;
 		let (spec_now, _) = ctx.client.get_runtime_version().await?;
 		if spec_now > spec_before {
-			let refund_decision =
-				quantus_subxt::api::tx().tech_referenda().refund_decision_deposit(index);
-			let refund_submission =
-				quantus_subxt::api::tx().tech_referenda().refund_submission_deposit(index);
-			let refund_result_a = submit_ok(ctx, &alice, refund_decision).await;
-			let refund_result_b = submit_ok(ctx, &alice, refund_submission).await;
-			let refunds = match (refund_result_a, refund_result_b) {
-				(Ok(_), Ok(_)) => "deposits refunded",
-				_ => "deposit refund not yet available (referendum bookkeeping pending)",
-			};
+			let refunds = refund_deposits(ctx, index).await;
 			return Ok(format!(
 				"runtime upgraded via referendum #{index}: spec {spec_before} → {spec_now}; {refunds}"
 			));
 		}
 		if std::time::Instant::now() > deadline {
-			let info_addr =
-				quantus_subxt::api::storage().tech_referenda().referendum_info_for(index);
-			let latest = ctx.client.get_latest_block().await?;
-			let info = ctx.client.client().storage().at(latest).fetch(&info_addr).await?;
+			let info = referendum_state(ctx, index).await?;
 			return Err(QuantusError::Generic(format!(
 				"spec version still {spec_before} after {timeout_secs}s; referendum #{index} \
-				 state: {info:?}. Is the node built with the fast-governance feature and the \
+				 state: {info}. Is the node built with the fast-governance feature and the \
 				 WASM spec_version higher than {spec_before}?"
 			)));
 		}
 	}
+}
+
+/// Re-install the current on-chain runtime: a Root referendum authorizes the
+/// code hash (`authorize_upgrade_without_checks`), then the full code is
+/// supplied with `apply_authorized_upgrade`.
+async fn governance_self_upgrade(ctx: &mut ExerciseCtx, timeout_secs: u64) -> Result<String> {
+	let (spec, _) = ctx.client.get_runtime_version().await?;
+
+	let latest = ctx.client.get_latest_block().await?;
+	let code = ctx
+		.client
+		.client()
+		.storage()
+		.at(latest)
+		.fetch_raw(b":code".to_vec())
+		.await?
+		.ok_or_else(|| QuantusError::Generic(":code storage entry not found".to_string()))?;
+	let code_hash: sp_core::H256 = BlakeTwo256::hash(&code);
+	crate::log_status!(
+		"⬆️  Self-upgrade phase: re-installing the current runtime ({} bytes, spec {}, hash \
+		 {code_hash:?})",
+		code.len(),
+		spec
+	);
+
+	let authorize = quantus_subxt::api::tx().system().authorize_upgrade_without_checks(code_hash);
+	let encoded = authorize.encode_call_data(&ctx.client.client().metadata()).map_err(|e| {
+		QuantusError::Generic(format!("failed to encode authorize_upgrade_without_checks: {e:?}"))
+	})?;
+	let index = submit_root_referendum(ctx, encoded).await?;
+
+	// Wait for enactment: the authorization shows up in System::AuthorizedUpgrade.
+	let authorized_addr = quantus_subxt::api::storage().system().authorized_upgrade();
+	let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+	loop {
+		tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+		let latest = ctx.client.get_latest_block().await?;
+		if let Some(authorized) =
+			ctx.client.client().storage().at(latest).fetch(&authorized_addr).await?
+		{
+			if authorized.code_hash != code_hash {
+				return Err(QuantusError::Generic(format!(
+					"unexpected authorized upgrade hash: {:?} (expected {code_hash:?})",
+					authorized.code_hash
+				)));
+			}
+			break;
+		}
+		if std::time::Instant::now() > deadline {
+			let info = referendum_state(ctx, index).await?;
+			return Err(QuantusError::Generic(format!(
+				"upgrade not authorized within {timeout_secs}s; referendum #{index} state: \
+				 {info}. Is the node built with the fast-governance feature?"
+			)));
+		}
+	}
+	crate::log_status!("⬆️  Upgrade authorized on-chain; applying the code blob…");
+
+	// The spec version will not change, so the code write is detected via the
+	// System::CodeUpdated event; start watching from before apply is submitted.
+	let mut last_seen = ctx.client.get_latest_block().await?;
+	let apply = quantus_subxt::api::tx().system().apply_authorized_upgrade(code);
+	let alice = ctx.alice.clone();
+	submit_ok(ctx, &alice, apply).await?;
+
+	let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+	loop {
+		if let Some(block_hash) = find_code_updated_since(ctx, &mut last_seen).await? {
+			let (spec_after, _) = ctx.client.get_runtime_version().await?;
+			if spec_after != spec {
+				return Err(QuantusError::Generic(format!(
+					"no-op self-upgrade unexpectedly changed the spec version: {spec} → {spec_after}"
+				)));
+			}
+			let refunds = refund_deposits(ctx, index).await;
+			return Ok(format!(
+				"current runtime (spec {spec}) re-installed via referendum #{index} \
+				 (authorize_upgrade_without_checks + apply_authorized_upgrade); \
+				 System::CodeUpdated observed in block {block_hash:?}; {refunds}"
+			));
+		}
+		if std::time::Instant::now() > deadline {
+			return Err(QuantusError::Generic(format!(
+				"apply_authorized_upgrade was included but no System::CodeUpdated event was \
+				 observed within {timeout_secs}s"
+			)));
+		}
+		tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+	}
+}
+
+/// Scan every block from (but excluding) `last_seen` up to the current best
+/// block for a `System::CodeUpdated` event, walking parent hashes so no block
+/// is skipped between polls. Advances `last_seen` to the scanned tip.
+async fn find_code_updated_since(
+	ctx: &ExerciseCtx,
+	last_seen: &mut subxt::utils::H256,
+) -> Result<Option<subxt::utils::H256>> {
+	let tip = ctx.client.get_latest_block().await?;
+	if tip == *last_seen {
+		return Ok(None);
+	}
+
+	// Newest-first walk back to last_seen. The cap guards against reorgs on the
+	// PoW chain where last_seen may no longer be an ancestor of the new tip.
+	let mut chain = Vec::new();
+	let mut cursor = tip;
+	while cursor != *last_seen && chain.len() < 64 {
+		chain.push(cursor);
+		cursor = ctx.client.client().blocks().at(cursor).await?.header().parent_hash;
+	}
+
+	for block_hash in chain.into_iter().rev() {
+		let events = ctx.client.client().blocks().at(block_hash).await?.events().await?;
+		if events
+			.find_first::<quantus_subxt::api::system::events::CodeUpdated>()
+			.map_err(|e| QuantusError::Generic(format!("failed to decode events: {e:?}")))?
+			.is_some()
+		{
+			*last_seen = tip;
+			return Ok(Some(block_hash));
+		}
+	}
+	*last_seen = tip;
+	Ok(None)
 }

--- a/src/cli/exercise/scenarios/wormhole.rs
+++ b/src/cli/exercise/scenarios/wormhole.rs
@@ -46,7 +46,7 @@ async fn multiround(
 		.create_wallet_with_scheme(
 			&wallet_name,
 			None,
-			crate::wallet::DEFAULT_DERIVATION_PATH,
+			crate::wallet::default_derivation_path(scheme),
 			scheme,
 		)
 		.await?;

--- a/src/cli/wallet.rs
+++ b/src/cli/wallet.rs
@@ -5,8 +5,9 @@ use crate::{
 	error::QuantusError,
 	log_error, log_print, log_success, log_verbose,
 	wallet::{
+		default_derivation_path,
 		password::{get_mnemonic_from_user, get_new_wallet_password},
-		default_derivation_path, DilithiumScheme, WalletManager,
+		DilithiumScheme, WalletManager,
 	},
 };
 use clap::Subcommand;
@@ -382,9 +383,8 @@ pub async fn handle_wallet_command(
 					.create_wallet_no_derivation_with_scheme(&name, Some(&final_password), scheme)
 					.await
 			} else {
-				let path = derivation_path
-					.as_deref()
-					.unwrap_or_else(|| default_derivation_path(scheme));
+				let path =
+					derivation_path.as_deref().unwrap_or_else(|| default_derivation_path(scheme));
 				wallet_manager
 					.create_wallet_with_scheme(&name, Some(&final_password), path, scheme)
 					.await
@@ -681,9 +681,8 @@ pub async fn handle_wallet_command(
 					)
 					.await
 			} else {
-				let path = derivation_path
-					.as_deref()
-					.unwrap_or_else(|| default_derivation_path(scheme));
+				let path =
+					derivation_path.as_deref().unwrap_or_else(|| default_derivation_path(scheme));
 				wallet_manager
 					.import_wallet_with_scheme(
 						&name,

--- a/src/cli/wallet.rs
+++ b/src/cli/wallet.rs
@@ -6,7 +6,7 @@ use crate::{
 	log_error, log_print, log_success, log_verbose,
 	wallet::{
 		password::{get_mnemonic_from_user, get_new_wallet_password},
-		DilithiumScheme, WalletManager, DEFAULT_DERIVATION_PATH,
+		default_derivation_path, DilithiumScheme, WalletManager,
 	},
 };
 use clap::Subcommand;
@@ -37,9 +37,10 @@ pub enum WalletCommands {
 		#[arg(long)]
 		allow_empty_password: bool,
 
-		/// Derivation path (default: m/44'/189189'/0'/0/0)
-		#[arg(short = 'd', long, default_value = DEFAULT_DERIVATION_PATH)]
-		derivation_path: String,
+		/// Derivation path (default depends on --scheme: ML-DSA-65 →
+		/// m/44'/189189'/0'/0'/1', ML-DSA-87 → m/44'/189189'/0'/0'/0')
+		#[arg(short = 'd', long)]
+		derivation_path: Option<String>,
 
 		/// Disable HD derivation (use master seed directly, like quantus-node --no-derivation)
 		#[arg(long)]
@@ -99,9 +100,10 @@ pub enum WalletCommands {
 		#[arg(long)]
 		allow_empty_password: bool,
 
-		/// Derivation path (default: m/44'/189189'/0'/0/0)
-		#[arg(short = 'd', long, default_value = DEFAULT_DERIVATION_PATH)]
-		derivation_path: String,
+		/// Derivation path (default depends on --scheme: ML-DSA-65 →
+		/// m/44'/189189'/0'/0'/1', ML-DSA-87 → m/44'/189189'/0'/0'/0')
+		#[arg(short = 'd', long)]
+		derivation_path: Option<String>,
 
 		/// Disable HD derivation (use master seed directly, like quantus-node --no-derivation)
 		#[arg(long)]
@@ -380,13 +382,11 @@ pub async fn handle_wallet_command(
 					.create_wallet_no_derivation_with_scheme(&name, Some(&final_password), scheme)
 					.await
 			} else {
+				let path = derivation_path
+					.as_deref()
+					.unwrap_or_else(|| default_derivation_path(scheme));
 				wallet_manager
-					.create_wallet_with_scheme(
-						&name,
-						Some(&final_password),
-						&derivation_path,
-						scheme,
-					)
+					.create_wallet_with_scheme(&name, Some(&final_password), path, scheme)
 					.await
 			};
 
@@ -681,12 +681,15 @@ pub async fn handle_wallet_command(
 					)
 					.await
 			} else {
+				let path = derivation_path
+					.as_deref()
+					.unwrap_or_else(|| default_derivation_path(scheme));
 				wallet_manager
 					.import_wallet_with_scheme(
 						&name,
 						&mnemonic_phrase,
 						Some(&final_password),
-						&derivation_path,
+						path,
 						scheme,
 					)
 					.await
@@ -1046,5 +1049,37 @@ mod tests {
 			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		]);
 		assert!(result.is_err(), "wallet from-seed must not accept --seed on the command line");
+	}
+
+	#[test]
+	fn wallet_scheme_cli_uses_hyphen_before_security_level() {
+		let parsed = TestCli::try_parse_from([
+			"quantus",
+			"wallet",
+			"create",
+			"--name",
+			"poc",
+			"--scheme",
+			"ml-dsa-87",
+			"--allow-empty-password",
+		])
+		.expect("ml-dsa-87 must parse");
+		match parsed.command {
+			crate::cli::Commands::Wallet(WalletCommands::Create { scheme, .. }) =>
+				assert_eq!(scheme, DilithiumScheme::MlDsa87),
+			other => panic!("expected Wallet(Create), got {other:?}"),
+		}
+
+		let legacy = TestCli::try_parse_from([
+			"quantus",
+			"wallet",
+			"create",
+			"--name",
+			"poc",
+			"--scheme",
+			"ml-dsa87",
+			"--allow-empty-password",
+		]);
+		assert!(legacy.is_err(), "unhyphenated ml-dsa87 must not parse");
 	}
 }

--- a/src/wallet/keystore.rs
+++ b/src/wallet/keystore.rs
@@ -42,10 +42,13 @@ use sp_runtime::traits::IdentifyAccount;
 /// CLI create/import defaults to [`Self::MlDsa65`]. Missing `scheme` when
 /// deserializing older encrypted wallets defaults to [`Self::MlDsa87`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
-#[clap(rename_all = "kebab-case")]
-#[serde(rename_all = "kebab-case")]
 pub enum DilithiumScheme {
+	/// Clap's kebab-case would emit `ml-dsa65` (no hyphen before digits); name it explicitly.
+	#[value(name = "ml-dsa-65")]
+	#[serde(rename = "ml-dsa-65", alias = "ml-dsa65")]
 	MlDsa65,
+	#[value(name = "ml-dsa-87")]
+	#[serde(rename = "ml-dsa-87", alias = "ml-dsa87")]
 	MlDsa87,
 }
 
@@ -888,6 +891,21 @@ mod tests {
 		let mut secret = vec![1u8, 2, 3, 4, 5];
 		zeroize_bytes(&mut secret);
 		assert!(secret.iter().all(|&b| b == 0));
+	}
+
+	#[test]
+	fn dilithium_scheme_serde_uses_hyphenated_names() {
+		assert_eq!(serde_json::to_string(&DilithiumScheme::MlDsa65).unwrap(), "\"ml-dsa-65\"");
+		assert_eq!(serde_json::to_string(&DilithiumScheme::MlDsa87).unwrap(), "\"ml-dsa-87\"");
+		assert_eq!(
+			serde_json::from_str::<DilithiumScheme>("\"ml-dsa-65\"").unwrap(),
+			DilithiumScheme::MlDsa65
+		);
+		assert_eq!(
+			serde_json::from_str::<DilithiumScheme>("\"ml-dsa87\"").unwrap(),
+			DilithiumScheme::MlDsa87,
+			"legacy unhyphenated alias must still deserialize"
+		);
 	}
 
 	#[test]

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -57,8 +57,20 @@ fn pair_from_master_seed(seed: &[u8], scheme: DilithiumScheme) -> Result<Quantum
 	}
 }
 
-/// Default derivation path for Quantus wallets: m/44'/189189'/0'/0'/0'
+/// Default derivation path for ML-DSA-87 (and legacy) Quantus wallets.
 pub const DEFAULT_DERIVATION_PATH: &str = "m/44'/189189'/0'/0'/0'";
+
+/// Default derivation path for ML-DSA-65 wallets. Last index differs from
+/// [`DEFAULT_DERIVATION_PATH`] so the two schemes never collide for the same mnemonic.
+pub const DEFAULT_DERIVATION_PATH_ML_DSA_65: &str = "m/44'/189189'/0'/0'/1'";
+
+/// Scheme-specific default HD path: ML-DSA-65 → `.../1'`, ML-DSA-87 → `.../0'`.
+pub fn default_derivation_path(scheme: DilithiumScheme) -> &'static str {
+	match scheme {
+		DilithiumScheme::MlDsa65 => DEFAULT_DERIVATION_PATH_ML_DSA_65,
+		DilithiumScheme::MlDsa87 => DEFAULT_DERIVATION_PATH,
+	}
+}
 
 /// Wallet information structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,7 +124,7 @@ impl WalletManager {
 		self.create_wallet_with_scheme(
 			name,
 			password,
-			DEFAULT_DERIVATION_PATH,
+			default_derivation_path(DilithiumScheme::MlDsa65),
 			DilithiumScheme::MlDsa65,
 		)
 		.await
@@ -298,7 +310,7 @@ impl WalletManager {
 			name,
 			mnemonic,
 			password,
-			DEFAULT_DERIVATION_PATH,
+			default_derivation_path(DilithiumScheme::MlDsa65),
 			DilithiumScheme::MlDsa65,
 		)
 		.await
@@ -1043,6 +1055,53 @@ mod tests {
 			.expect("Failed to import wallet again");
 
 		assert_eq!(imported_wallet.address, imported_wallet2.address);
+	}
+
+	#[test]
+	fn default_derivation_path_is_scheme_specific() {
+		assert_eq!(default_derivation_path(DilithiumScheme::MlDsa87), DEFAULT_DERIVATION_PATH);
+		assert_eq!(
+			default_derivation_path(DilithiumScheme::MlDsa65),
+			DEFAULT_DERIVATION_PATH_ML_DSA_65
+		);
+		assert_ne!(DEFAULT_DERIVATION_PATH, DEFAULT_DERIVATION_PATH_ML_DSA_65);
+		assert!(DEFAULT_DERIVATION_PATH.ends_with("/0'"));
+		assert!(DEFAULT_DERIVATION_PATH_ML_DSA_65.ends_with("/1'"));
+	}
+
+	#[tokio::test]
+	async fn default_paths_separate_schemes_for_same_mnemonic() {
+		sp_core::crypto::set_default_ss58_version(sp_core::crypto::Ss58AddressFormat::custom(189));
+		let (wallet_manager, _temp_dir) = create_test_wallet_manager().await;
+		let mnemonic = "orchard answer curve patient visual flower maze noise retreat penalty cage small earth domain scan pitch bottom crunch theme club client swap slice raven";
+
+		let wallet_65 = wallet_manager
+			.import_wallet_with_scheme(
+				"scheme-65",
+				mnemonic,
+				None,
+				default_derivation_path(DilithiumScheme::MlDsa65),
+				DilithiumScheme::MlDsa65,
+			)
+			.await
+			.expect("import 65");
+		let wallet_87 = wallet_manager
+			.import_wallet_with_scheme(
+				"scheme-87",
+				mnemonic,
+				None,
+				default_derivation_path(DilithiumScheme::MlDsa87),
+				DilithiumScheme::MlDsa87,
+			)
+			.await
+			.expect("import 87");
+
+		assert_eq!(wallet_65.derivation_path, DEFAULT_DERIVATION_PATH_ML_DSA_65);
+		assert_eq!(wallet_87.derivation_path, DEFAULT_DERIVATION_PATH);
+		assert_ne!(
+			wallet_65.address, wallet_87.address,
+			"scheme-specific default paths must not collide for the same mnemonic"
+		);
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
# exercise: `--self-upgrade` smoke test + scheme-specific HD paths

## Summary

1. **`--self-upgrade`** — no-WASM exercise mode that proves the current runtime
   can drive a Root tech-referendum upgrade end-to-end, without building a
   spec-bumped candidate just to satisfy `can_set_code`.
2. **Scheme-specific default derivation paths** — ML-DSA-65 and ML-DSA-87 no
   longer share the same HD index, so the same mnemonic cannot collide across
   schemes.

```bash
# Requires a node built with quantus-runtime/fast-governance
quantus exercise --phases upgrade --self-upgrade --node-url ws://127.0.0.1:9944

# ML-DSA-87 (path …/0'); ML-DSA-65 defaults to …/1'
quantus wallet import --name my-wallet --scheme ml-dsa-87
quantus wallet create --name new-65   # scheme default ml-dsa-65 → …/1'
```

`--self-upgrade` is mutually exclusive with `--upgrade-wasm` (real upgrade +
post-upgrade re-run).

## Self-upgrade: why not `set_code` in the referendum?

- Resubmitting the current `:code` through `set_code` fails
  `can_set_code` with `SpecVersionNeedsToIncrease`.
- Putting the full blob in a referendum Lookup hits
  `TechReferenda::MaxProposalSize` (64 KiB); on-chain code is ~700 KiB+.

So the pipeline is the production-shaped authorize/apply path:

1. Fetch `:code` and hash it.
2. Root referendum enacts `system.authorize_upgrade_without_checks(hash)`.
3. Anyone supplies the blob via `system.apply_authorized_upgrade(code)`.
4. Success is `System::CodeUpdated` (spec version stays the same).

This covers preimage → tech-referenda submit → decision deposit → collective
votes → enactment → authorization → code write. What it deliberately skips is
the `spec_name` / `spec_version` comparison inside `can_set_code` (trivial; use
`--upgrade-wasm` with a real bumped runtime for that).

### Fast-governance vote race

Under `fast-governance`, prepare/decision/confirm are all 2 blocks. Sequential
wait-for-inclusion votes from alice → bob → charlie routinely miss the decision
window and fail with `TechCollective::NotPolling`. Collective ayes are now cast
in parallel; `NotPolling` is tolerated when the referendum is already
`Approved`.

## Scheme-specific derivation paths

| Scheme | Default path |
|--------|----------------|
| ML-DSA-87 | `m/44'/189189'/0'/0'/0'` |
| ML-DSA-65 | `m/44'/189189'/0'/0'/1'` |

`wallet create` / `wallet import` resolve the scheme default when `-d` is
omitted; an explicit `--derivation-path` still wins. `--no-derivation` is
unchanged. Wormhole exercise temp wallets use the same helper.

## Test plan

- [ ] Node built with `--features quantus-runtime/fast-governance` and run
      `--dev --tmp`
- [ ] `quantus exercise --phases upgrade --self-upgrade` passes
      (`governance_self_upgrade`, `System::CodeUpdated` observed, spec unchanged)
- [ ] `quantus exercise --phases upgrade` without flags still errors clearly
      (requires `--upgrade-wasm` or `--self-upgrade`)
- [ ] `--self-upgrade` conflicts with `--upgrade-wasm` at clap parse time
- [ ] `wallet create` (default scheme) stores derivation path `…/1'`
- [ ] `wallet import --scheme ml-dsa-87` stores derivation path `…/0'`
- [ ] `--scheme` help / parse accepts `ml-dsa-65` and `ml-dsa-87` (not `ml-dsa65`)
- [ ] Same mnemonic under default 65 vs 87 paths yields different addresses
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo test --locked --lib wallet::tests::default_` passes