### PR TITLE
ci: Automate version bump to v2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-cli"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-cli"
 readme = "README.md"
 repository = "https://github.com/Quantus-Network/quantus-cli"
-version = "2.0.0"
+version = "2.1.0"
 
 [lib]
 name = "quantus_cli"


### PR DESCRIPTION
Automated version bump for release v2.1.0.

https://github.com/Quantus-Network/quantus-cli/actions/runs/31458927251

Triggered by workflow run: minor

Type: 