### PR TITLE
ci: Automate version bump to v2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "quantus-cli"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "quantus-cli"
 readme = "README.md"
 repository = "https://github.com/Quantus-Network/quantus-cli"
-version = "2.1.0"
+version = "2.1.1"
 
 [lib]
 name = "quantus_cli"


### PR DESCRIPTION
Automated version bump for release v2.1.1.

https://github.com/Quantus-Network/quantus-cli/actions/runs/31474570839

Triggered by workflow run: patch

Type: 